### PR TITLE
ci: run jest on PRs to main and dev

### DIFF
--- a/.github/workflows/react-build-and-deploy.yml
+++ b/.github/workflows/react-build-and-deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -21,16 +23,20 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run lint
+      - run: npm test -- --watchAll=false
       - run: npm run build
       # хак для роутинга: index.html → 404.html
       - run: cp -f build/index.html build/404.html
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           path: build
           cname: pmtools.ru
 
   deploy:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/react-build-and-deploy.yml
+++ b/.github/workflows/react-build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: CI & Deploy to GitHub Pages
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,17 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm test -- --watchAll=false
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
       - run: npm run build
       # хак для роутинга: index.html → 404.html
       - run: cp -f build/index.html build/404.html


### PR DESCRIPTION
## Summary
- Phase 1 Step 0.1 from `.claude/development-roadmap/01-testing.md`.
- Runs `npm test -- --watchAll=false` in CI after `npm run lint` so the existing `mergeDir.test.ts` (and all future tests) are gated by CI.
- Adds `pull_request` triggers for both `main` and `dev` so the test suite runs on every PR before merge.
- Deploy-only steps (404.html copy, pages artifact upload, deploy job) are gated on `push` to `main` so PRs don't attempt to deploy.

## Test plan
- [x] `npm test -- --watchAll=false` passes locally (4/4 in `mergeDir.test.ts`).
- [x] `npm run verify` passes locally (0 errors).
- [x] `npm run build` passes locally.
- [ ] CI run on this PR is green — that's the actual gate Phase 1 needs before any new tests land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)