### PR TITLE
test: add fast-check devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pmtools_2.0",
-  "version": "2.6.1",
+  "version": "2.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pmtools_2.0",
-      "version": "2.6.1",
+      "version": "2.6.4",
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -56,6 +56,7 @@
         "@types/deep-equal": "^1.0.1",
         "@types/uuid": "^8.3.4",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.7.0",
         "file-loader": "^6.2.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -10212,6 +10213,29 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -17263,6 +17287,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -29298,6 +29339,15 @@
       "optional": true,
       "peer": true
     },
+    "fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^8.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -34312,6 +34362,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/deep-equal": "^1.0.1",
     "@types/uuid": "^8.3.4",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.7.0",
     "file-loader": "^6.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",


### PR DESCRIPTION
## Summary
- Phase 1 Step 0.2 from `.claude/development-roadmap/01-testing.md`.
- Adds `fast-check` (v4.x) as a devDependency. Used by upcoming property-based tests required by the Phase 1 exit criteria (Fisher mean idempotence, PCA colinearity, VGP roundtrip, Fisher-VGP composition).

## Seedable RNG decision
- Roadmap allows hand-rolled LCG **or** `seedrandom` and explicitly prefers the LCG ("integer state, ~10 lines, fully deterministic across engines").
- Going with hand-rolled LCG → no npm dep, integer state, bit-exact across JS engines and the eventual Phase 7 Rust port.
- LCG helper file (`src/__tests__/helpers/seededRng.ts`) ships in the next PR with the rest of the helpers/fixtures scaffold.

## Test plan
- [x] `npm test -- --watchAll=false` — 4/4 (existing `mergeDir.test.ts`)
- [x] `npm run verify` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)