### PR TITLE
test: add PmagPy fixture-generator script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,12 @@ PCA notes:
 - `directions` are PmagPy-native `[dec, inc, intensity]` rows. PMTools works
   internally in cartesian, so the fixture writer is responsible for the
   conversion when authoring the input.
+- Internally `gen_pca` wraps each row into the 5-column form
+  `[step, dec, inc, intensity, "g"]` (treatment step = row index, quality =
+  "good") before calling `pmag.domean` — the function indexes `row[5]` for
+  the quality flag and crashes with `IndexError` on 3-column input. This
+  wrapping is a `pmag.domean` API requirement, not part of the input.json
+  schema; fixture authors keep writing `[dec, inc, intensity]` tuples.
 - `calculation_type` defaults to `DE-BFL`. Use `DE-BFL-A` for anchored PCA
   (matches PMTools `calculatePCA_pmd(..., anchored=true)`) and `DE-BFP` for
   great-circle / plane fits (matches `calculatePCA_dir`).
@@ -77,16 +83,25 @@ PCA notes:
 Field mappings in the output JSON:
 - Fisher: `pmagpy alpha95 → fisher_mean.a95`. PMTools' `MeanDir.MAD` is
   semantically α95 for Fisher, despite the field name.
-- PCA: `specimen_dec/inc/mad/n → principal.dec/inc/mad/n`. `center_of_mass`
-  is omitted for now (np.array, fiddly to serialize); add it explicitly if a
-  Step 2 fixture needs it.
+- PCA: `specimen_dec/inc/mad/dang/n → principal.dec/inc/mad/dang/n`. DANG
+  (Demagnetization Angle — angle between the PCA line and the line from the
+  center of mass to the origin) is captured as a free quality metric; PMTools
+  computes the same value, so it makes a useful second parity axis once Step 2
+  fixtures land. `center_of_mass` is omitted for now (np.array, fiddly to
+  serialize); add it explicitly if a Step 2 fixture needs it.
 
 Stubs print an error and exit 1 — they are filled in as Phase 1 adds tests
 for the corresponding statistics module. When you implement a stub:
 
-1. Add the per-topic `gen_<topic>` function in `generate_fixtures.py`.
-2. Document the input shape in this table.
-3. Update the fixture's `SOURCE.md` so reviewers know what schema to use.
+1. Create `scripts/gen_<topic>.py` with a `gen_<topic>(args)` function (see
+   `gen_fisher.py` / `gen_pca.py` for the pattern: import helpers from
+   `_fixture_common`, call `require_pmagpy()`, iterate `discover_inputs`,
+   write via `write_output`).
+2. In `generate_fixtures.py`, replace the `gen_stub("<topic>")` entry in the
+   `GENERATORS` dict with `from gen_<topic> import gen_<topic>` at the top
+   and the imported function in the dict.
+3. Document the input shape in this table.
+4. Update the fixture's `SOURCE.md` so reviewers know what schema to use.
 
 ### Investigating PmagPy parity disagreements
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,87 @@
+# scripts/
+
+Helper scripts for PMTools development. Run from the repo root.
+
+## generate_fixtures.py
+
+Regenerates PmagPy comparison fixtures used by the Phase 1 Jest suite.
+PmagPy is the de-facto standard paleomagnetism toolkit (Tauxe / Swanson-Hysell);
+PMTools tests cross-check selected computations against it.
+
+### When to run it
+
+Only when adding or updating a fixture in `src/__tests__/fixtures/<topic>/`.
+CI **never** runs this script — the test suite reads the committed
+`*.pmagpy.json` files directly. Python is not required to run `npm test`.
+
+### Setup
+
+1. Python 3.9 or later (already on macOS by default; check `python3 --version`).
+2. Install PmagPy:
+   ```bash
+   pip install pmagpy
+   ```
+3. Verify it imports:
+   ```bash
+   python3 -c "from pmagpy import pmag; print('pmagpy OK')"
+   ```
+
+The script writes `pmagpy_version` into every output JSON. Don't bump the
+version casually: regeneration with a different PmagPy version may produce
+floating-point drift that looks like a regression. If you do bump, document it
+in the commit message and re-run `npm test` to confirm tolerances still hold.
+
+### Usage
+
+```bash
+# regenerate Fisher-mean fixtures
+python3 scripts/generate_fixtures.py fisher
+
+# regenerate everything that has an implemented generator
+python3 scripts/generate_fixtures.py all
+
+# overwrite existing outputs (default behavior is skip-if-exists)
+python3 scripts/generate_fixtures.py fisher --force
+```
+
+### Input format
+
+Each fixture lives at `src/__tests__/fixtures/<topic>/<name>.input.json` and
+the script writes `<name>.pmagpy.json` next to it.
+
+| Topic | Input shape | PmagPy routine |
+|---|---|---|
+| `fisher` | `{ "directions": [[D, I], …] }` | `pmag.fisher_mean` |
+| `pca` | `{ "vectors": [[x, y, z], …], "anchored": false }` | `pmag.doprinc` |
+| `watson` | _stub_ | `pmag.watsons_v` (planned) |
+| `vgp` | _stub_ | `pmag.dia_vgp` (planned) |
+| `mcfadden` | _stub_ | `pmag.dolnp` (planned) |
+| `fold-test` | _stub_ | `pmag.bootstrap_fold_test` (planned) |
+| `cutoff` | _stub_ | Vandamme cutoff (planned) |
+| `bootstrap` | _stub_ | seeded bootstrap (planned) |
+
+Stubs print an error and exit 1 — they are filled in as Phase 1 adds tests
+for the corresponding statistics module. When you implement a stub:
+
+1. Add the per-topic `gen_<topic>` function in `generate_fixtures.py`.
+2. Document the input shape in this table.
+3. Update the fixture's `SOURCE.md` so reviewers know what schema to use.
+
+### Investigating PmagPy parity disagreements
+
+If PMTools and PmagPy produce different output for the same input:
+
+1. Verify the input file matches the schema above (typos and unit confusions —
+   degrees vs. radians, intensity vs. unit vectors — are the most common cause).
+2. Re-run with the latest stable PmagPy and compare against the cited PMTools
+   thesis formula. The thesis cheat sheet lives at
+   `src/__tests__/fixtures/THESIS_FORMULAS.md`.
+3. The outcome is one of:
+   - **PMTools has a bug.** Fix it in a `fix(science):` commit and add the
+     failing fixture as the regression test. The thesis is the spec; the code
+     deviating from it is the bug.
+   - **PMTools uses a different convention** (e.g., Watson F-test vs. Watson
+     Vw, different α₉₅ approximation). Document the convention in the
+     fixture's `SOURCE.md` and keep the PMTools-side `<name>.expected.json`
+     as the source of truth. The PmagPy fixture is then a documented
+     reference, not a parity gate.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,10 +26,13 @@ CI **never** runs this script — the test suite reads the committed
    python3 -c "from pmagpy import pmag; print('pmagpy OK')"
    ```
 
-The script writes `pmagpy_version` into every output JSON. Don't bump the
-version casually: regeneration with a different PmagPy version may produce
-floating-point drift that looks like a regression. If you do bump, document it
-in the commit message and re-run `npm test` to confirm tolerances still hold.
+The script writes `pmagpy_version` into every output JSON. The version is read
+via `importlib.metadata.version("pmagpy")` (PyPI/installer metadata), not via
+`pmagpy.__version__` — the latter is not reliably set on the package. Don't
+bump the version casually: regeneration with a different PmagPy version may
+produce floating-point drift that looks like a regression. If you do bump,
+document it in the commit message and re-run `npm test` to confirm tolerances
+still hold.
 
 ### Usage
 
@@ -52,13 +55,31 @@ the script writes `<name>.pmagpy.json` next to it.
 | Topic | Input shape | PmagPy routine |
 |---|---|---|
 | `fisher` | `{ "directions": [[D, I], …] }` | `pmag.fisher_mean` |
-| `pca` | `{ "vectors": [[x, y, z], …], "anchored": false }` | `pmag.doprinc` |
+| `pca` | `{ "directions": [[D, I, int], …], "calculation_type": "DE-BFL" \| "DE-BFL-A" \| "DE-BFP" }` | `pmag.domean` |
 | `watson` | _stub_ | `pmag.watsons_v` (planned) |
 | `vgp` | _stub_ | `pmag.dia_vgp` (planned) |
 | `mcfadden` | _stub_ | `pmag.dolnp` (planned) |
-| `fold-test` | _stub_ | `pmag.bootstrap_fold_test` (planned) |
+| `fold_test` | _stub_ | `pmag.bootstrap_fold_test` (planned) |
 | `cutoff` | _stub_ | Vandamme cutoff (planned) |
 | `bootstrap` | _stub_ | seeded bootstrap (planned) |
+
+PCA notes:
+- `directions` are PmagPy-native `[dec, inc, intensity]` rows. PMTools works
+  internally in cartesian, so the fixture writer is responsible for the
+  conversion when authoring the input.
+- `calculation_type` defaults to `DE-BFL`. Use `DE-BFL-A` for anchored PCA
+  (matches PMTools `calculatePCA_pmd(..., anchored=true)`) and `DE-BFP` for
+  great-circle / plane fits (matches `calculatePCA_dir`).
+- `pmag.doprinc` is intentionally **not** used: it expects `[dec, inc, int]`
+  too (despite older docs suggesting cartesian), but it does not return MAD
+  and has no anchored mode, so it can't act as a parity oracle for PMTools.
+
+Field mappings in the output JSON:
+- Fisher: `pmagpy alpha95 → fisher_mean.a95`. PMTools' `MeanDir.MAD` is
+  semantically α95 for Fisher, despite the field name.
+- PCA: `specimen_dec/inc/mad/n → principal.dec/inc/mad/n`. `center_of_mass`
+  is omitted for now (np.array, fiddly to serialize); add it explicitly if a
+  Step 2 fixture needs it.
 
 Stubs print an error and exit 1 — they are filled in as Phase 1 adds tests
 for the corresponding statistics module. When you implement a stub:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,21 @@ python3 scripts/generate_fixtures.py all
 python3 scripts/generate_fixtures.py fisher --force
 ```
 
+### Conventions
+
+PmagPy is unit-agnostic about labels but strict about expectations:
+
+- **Angles are degrees**, never radians. `dec ∈ [0, 360)`, `inc ∈ [-90, 90]`.
+- **Inclination sign**: positive = downward (paleomag standard, matches
+  PMTools). A vector pointing into the ground has `inc > 0`.
+- **Coordinate system**: PmagPy doesn't know whether your `[dec, inc]` is
+  in specimen, geographic, or stratigraphic coordinates — it just runs the
+  math. The fixture's `SOURCE.md` **must** state which coordinate system
+  the input is in, otherwise PMTools-side parity assertions are ambiguous.
+- **Hemisphere**: PmagPy returns lower-hemisphere directions by default
+  (`pmag.doflip` is applied internally for principal components). PMTools
+  matches this convention.
+
 ### Input format
 
 Each fixture lives at `src/__tests__/fixtures/<topic>/<name>.input.json` and
@@ -66,16 +81,23 @@ the script writes `<name>.pmagpy.json` next to it.
 PCA notes:
 - `directions` are PmagPy-native `[dec, inc, intensity]` rows. PMTools works
   internally in cartesian, so the fixture writer is responsible for the
-  conversion when authoring the input.
-- Internally `gen_pca` wraps each row into the 5-column form
-  `[step, dec, inc, intensity, "g"]` (treatment step = row index, quality =
-  "good") before calling `pmag.domean` — the function indexes `row[5]` for
-  the quality flag and crashes with `IndexError` on 3-column input. This
-  wrapping is a `pmag.domean` API requirement, not part of the input.json
-  schema; fixture authors keep writing `[dec, inc, intensity]` tuples.
+  conversion when authoring the input. Intensity matters: `DE-BFL` (line fit)
+  is weighted by vector magnitudes, so use the real demag-step magnitude;
+  `DE-BFP` (plane fit) overwrites intensity with 1.0 internally, so any
+  positive value works.
+- Internally `gen_pca` wraps each row into the 6-column form
+  `[step, dec, inc, intensity, "", "g"]` before calling `pmag.domean`. Index
+  layout: `[0]` treatment step (synthesized as row index), `[1]` dec, `[2]`
+  inc, `[3]` intensity, `[4]` Zijderveld step type (unused by `domean`),
+  `[5]` quality flag (`'g'`/`'b'`). This wrapping is a `pmag.domean` API
+  requirement, not part of the input.json schema; fixture authors keep
+  writing `[dec, inc, intensity]` tuples.
 - `calculation_type` defaults to `DE-BFL`. Use `DE-BFL-A` for anchored PCA
   (matches PMTools `calculatePCA_pmd(..., anchored=true)`) and `DE-BFP` for
   great-circle / plane fits (matches `calculatePCA_dir`).
+- For `DE-BFP` the returned `dec`/`inc` is the **pole of the plane**, not
+  a line direction, and `mad` follows thesis formula §1.2 (great-circle MAD)
+  instead of §1.1 (vector MAD). Compare against the matching PMTools field.
 - `pmag.doprinc` is intentionally **not** used: it expects `[dec, inc, int]`
   too (despite older docs suggesting cartesian), but it does not return MAD
   and has no anchored mode, so it can't act as a parity oracle for PMTools.
@@ -83,12 +105,21 @@ PCA notes:
 Field mappings in the output JSON:
 - Fisher: `pmagpy alpha95 → fisher_mean.a95`. PMTools' `MeanDir.MAD` is
   semantically α95 for Fisher, despite the field name.
+- Fisher edge cases: for `N == R` (perfectly parallel directions) PmagPy
+  writes `k` as the **string** `"inf"` rather than a float, and `csd` as 0.
+  For `N == 1` PmagPy returns only `dec`/`inc` and the script writes `null`
+  for everything else. Both states are valid signals of degenerate input,
+  not parity gates — flag in the fixture's `SOURCE.md`.
 - PCA: `specimen_dec/inc/mad/dang/n → principal.dec/inc/mad/dang/n`. DANG
   (Demagnetization Angle — angle between the PCA line and the line from the
   center of mass to the origin) is captured as a free quality metric; PMTools
   computes the same value, so it makes a useful second parity axis once Step 2
   fixtures land. `center_of_mass` is omitted for now (np.array, fiddly to
   serialize); add it explicitly if a Step 2 fixture needs it.
+- PCA `DE-BFL-A` exception: PmagPy's anchored path returns before computing
+  DANG, so `principal.dang` is **always** `null` for anchored fixtures. This
+  is a PmagPy quirk, not a script bug — don't add `dang` to the parity
+  assertion when `calculation_type === "DE-BFL-A"`.
 
 Stubs print an error and exit 1 — they are filled in as Phase 1 adds tests
 for the corresponding statistics module. When you implement a stub:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,10 +78,19 @@ If PMTools and PmagPy produce different output for the same input:
    `src/__tests__/fixtures/THESIS_FORMULAS.md`.
 3. The outcome is one of:
    - **PMTools has a bug.** Fix it in a `fix(science):` commit and add the
-     failing fixture as the regression test. The thesis is the spec; the code
-     deviating from it is the bug.
+     failing fixture as the regression test. By default the thesis is the spec
+     and code deviating from it is the bug.
    - **PMTools uses a different convention** (e.g., Watson F-test vs. Watson
      Vw, different α₉₅ approximation). Document the convention in the
      fixture's `SOURCE.md` and keep the PMTools-side `<name>.expected.json`
      as the source of truth. The PmagPy fixture is then a documented
      reference, not a parity gate.
+   - **The thesis formula itself is wrong.** Hypothetically possible — the
+     thesis was checked many times and the work is long-accepted by the
+     paleomag community, but blind trust is still wrong for scientific code.
+     If a derivation error in the thesis is found: cite the original source
+     (Kirschvink 1980, Fisher 1953, etc.) in the fixture's `SOURCE.md`,
+     update the thesis cheat sheet at `src/__tests__/fixtures/THESIS_FORMULAS.md`
+     with a clarifying note, fix the code if needed in a `fix(science):` commit,
+     and flag the discrepancy in the PR description so a domain expert reviews
+     it before merge.

--- a/scripts/_fixture_common.py
+++ b/scripts/_fixture_common.py
@@ -1,0 +1,80 @@
+"""Shared infrastructure for the per-topic fixture generators.
+
+Used by `gen_*.py` siblings; not invoked directly. The leading underscore
+marks this as internal helper code, not a generator topic.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_ROOT = REPO_ROOT / "src" / "__tests__" / "fixtures"
+INPUT_SUFFIX = ".input.json"
+OUTPUT_SUFFIX = ".pmagpy.json"
+
+PCA_CALC_TYPES = {"DE-BFL", "DE-BFL-A", "DE-BFP"}
+
+
+class StubNotImplemented(Exception):
+    """Topic is registered in the CLI but has no generator yet."""
+
+
+@functools.lru_cache(maxsize=1)
+def require_pmagpy():
+    try:
+        from pmagpy import pmag  # type: ignore[import-not-found]
+    except ImportError:
+        sys.exit(
+            "PmagPy is not installed.\n"
+            "Run:  pip install pmagpy\n"
+            "Then re-run this script."
+        )
+    return pmag
+
+
+def pmagpy_version() -> str:
+    # PmagPy doesn't reliably set __version__ on the package, so read the
+    # PyPI/installer-recorded version instead.
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return "unknown"
+    try:
+        return version("pmagpy")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def discover_inputs(topic_dir: Path) -> list[Path]:
+    if not topic_dir.is_dir():
+        return []
+    return sorted(topic_dir.glob(f"*{INPUT_SUFFIX}"))
+
+
+def output_path_for(input_path: Path) -> Path:
+    stem = input_path.name[: -len(INPUT_SUFFIX)]
+    return input_path.parent / f"{stem}{OUTPUT_SUFFIX}"
+
+
+def load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        try:
+            return json.load(fh)
+        except json.JSONDecodeError as exc:
+            sys.exit(f"{path.relative_to(REPO_ROOT)}: invalid JSON — {exc}")
+
+
+def write_output(output_path: Path, data: dict, force: bool, label: str) -> bool:
+    if output_path.exists() and not force:
+        rel = output_path.relative_to(REPO_ROOT)
+        print(f"[{label}] skip {rel} (exists; pass --force to overwrite)")
+        return False
+    with open(output_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    print(f"[{label}] wrote {output_path.relative_to(REPO_ROOT)}")
+    return True

--- a/scripts/gen_fisher.py
+++ b/scripts/gen_fisher.py
@@ -1,0 +1,45 @@
+"""Fisher mean fixture generator. See scripts/README.md for the input shape."""
+
+from __future__ import annotations
+
+import argparse
+
+from _fixture_common import (
+    FIXTURES_ROOT,
+    discover_inputs,
+    load_json,
+    output_path_for,
+    pmagpy_version,
+    require_pmagpy,
+    write_output,
+)
+
+
+def gen_fisher(args: argparse.Namespace) -> None:
+    pmag = require_pmagpy()
+    inputs = discover_inputs(FIXTURES_ROOT / "fisher")
+    if not inputs:
+        print("[fisher] no *.input.json files yet; nothing to do")
+        return
+    for inp in inputs:
+        data = load_json(inp)
+        directions = data.get("directions") or []
+        if not directions:
+            print(f"[fisher] {inp.name}: missing or empty 'directions'; skipping")
+            continue
+        # pmag.fisher_mean: input is list of [dec, inc] pairs.
+        # Returns a dict with dec, inc, k, alpha95, csd, n, r.
+        result = pmag.fisher_mean(directions)
+        out = {
+            "pmagpy_version": pmagpy_version(),
+            "fisher_mean": {
+                "dec": result.get("dec"),
+                "inc": result.get("inc"),
+                "k": result.get("k"),
+                "a95": result.get("alpha95"),
+                "csd": result.get("csd"),
+                "n": result.get("n"),
+                "r": result.get("r"),
+            },
+        }
+        write_output(output_path_for(inp), out, args.force, "fisher")

--- a/scripts/gen_pca.py
+++ b/scripts/gen_pca.py
@@ -6,6 +6,8 @@ See scripts/README.md for the input shape and the PmagPy `pmag.domean` notes.
 from __future__ import annotations
 
 import argparse
+import copy
+import sys
 
 from _fixture_common import (
     FIXTURES_ROOT,
@@ -25,6 +27,7 @@ def gen_pca(args: argparse.Namespace) -> None:
     if not inputs:
         print("[pca] no *.input.json files yet; nothing to do")
         return
+    bad_calc_types: list[str] = []
     for inp in inputs:
         data = load_json(inp)
         directions = data.get("directions") or []
@@ -35,8 +38,9 @@ def gen_pca(args: argparse.Namespace) -> None:
         if calc_type not in PCA_CALC_TYPES:
             print(
                 f"[pca] {inp.name}: bad calculation_type {calc_type!r} "
-                f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
+                f"(expected one of {sorted(PCA_CALC_TYPES)})"
             )
+            bad_calc_types.append(inp.name)
             continue
         # pmag.domean expects 6-column rows: [treatment, dec, inc, intensity, ZI, quality].
         # Index 5 is the 'g'/'b' quality flag (read at pmag.py:2899). If a row
@@ -51,7 +55,10 @@ def gen_pca(args: argparse.Namespace) -> None:
         datablock = [
             [i, d[0], d[1], d[2], "", "g"] for i, d in enumerate(directions)
         ]
-        result = pmag.domean(datablock, 0, len(datablock) - 1, calc_type)
+        # pmag.domean mutates rows in place (rec.append at pmag.py:2896).
+        # deepcopy keeps the input pristine for any future re-use within
+        # the same run.
+        result = pmag.domean(copy.deepcopy(datablock), 0, len(datablock) - 1, calc_type)
         # pmag.domean returns {'specimen_direction_type': 'Error', ...} when its
         # eigendecomposition fails; everything else is missing. Don't write a
         # JSON full of nulls and pretend it's a parity oracle.
@@ -71,3 +78,10 @@ def gen_pca(args: argparse.Namespace) -> None:
             },
         }
         write_output(output_path_for(inp), out, args.force, "pca")
+
+    if bad_calc_types:
+        sys.exit(
+            f"[pca] {len(bad_calc_types)} fixture(s) had invalid calculation_type "
+            f"and were not generated: {', '.join(bad_calc_types)}. "
+            f"Fix the input.json files and re-run."
+        )

--- a/scripts/gen_pca.py
+++ b/scripts/gen_pca.py
@@ -38,16 +38,26 @@ def gen_pca(args: argparse.Namespace) -> None:
                 f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
             )
             continue
-        # pmag.domean wants 5+ column rows: [treatment, dec, inc, intensity, quality].
-        # It indexes row[5] for the 'g'/'b' quality flag (3-column input crashes
-        # with IndexError). We synthesize treatment as the row index and mark
-        # every point 'g' (good) since the input.json schema deliberately hides
-        # this from fixture authors — they write [dec, inc, intensity] tuples.
-        # start/end are inclusive. doprinc is NOT used: no MAD, no anchored mode.
+        # pmag.domean expects 6-column rows: [treatment, dec, inc, intensity, ZI, quality].
+        # Index 5 is the 'g'/'b' quality flag (read at pmag.py:2899). If a row
+        # has fewer than 6 elements, domean appends a single 'g' (pmag.py:2895-2898),
+        # so 5-col rows survive but a 4-col row crashes with IndexError on the
+        # quality read. Index 4 is the Zijderveld step type ('Z'/'I'); domean
+        # itself never reads it, so we leave it empty. We write the full 6-col
+        # form explicitly rather than relying on the auto-pad. Treatment step is
+        # synthesized as the row index because the input.json schema hides this
+        # from fixture authors. start/end are 0-indexed and inclusive (pmag.py:2917,2923).
+        # doprinc is NOT used: it returns no MAD and has no anchored mode.
         datablock = [
-            [i, d[0], d[1], d[2], "g"] for i, d in enumerate(directions)
+            [i, d[0], d[1], d[2], "", "g"] for i, d in enumerate(directions)
         ]
         result = pmag.domean(datablock, 0, len(datablock) - 1, calc_type)
+        # pmag.domean returns {'specimen_direction_type': 'Error', ...} when its
+        # eigendecomposition fails; everything else is missing. Don't write a
+        # JSON full of nulls and pretend it's a parity oracle.
+        if result.get("specimen_direction_type") == "Error":
+            print(f"[pca] {inp.name}: pmag.domean returned Error; skipping")
+            continue
         out = {
             "pmagpy_version": pmagpy_version(),
             "calculation_type": calc_type,

--- a/scripts/gen_pca.py
+++ b/scripts/gen_pca.py
@@ -38,14 +38,16 @@ def gen_pca(args: argparse.Namespace) -> None:
                 f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
             )
             continue
-        # pmag.domean(data, start, end, calculation_type):
-        #   data         — list of [dec, inc, intensity] rows
-        #   start/end    — indices into data (inclusive)
-        #   calc type    — DE-BFL (free line), DE-BFL-A (anchored line), DE-BFP (plane)
-        # Returns specimen_dec, specimen_inc, specimen_mad, specimen_n,
-        # specimen_direction_type, center_of_mass, ...
-        # doprinc is NOT used: it doesn't return MAD and doesn't model anchored mode.
-        result = pmag.domean(directions, 0, len(directions) - 1, calc_type)
+        # pmag.domean wants 5+ column rows: [treatment, dec, inc, intensity, quality].
+        # It indexes row[5] for the 'g'/'b' quality flag (3-column input crashes
+        # with IndexError). We synthesize treatment as the row index and mark
+        # every point 'g' (good) since the input.json schema deliberately hides
+        # this from fixture authors — they write [dec, inc, intensity] tuples.
+        # start/end are inclusive. doprinc is NOT used: no MAD, no anchored mode.
+        datablock = [
+            [i, d[0], d[1], d[2], "g"] for i, d in enumerate(directions)
+        ]
+        result = pmag.domean(datablock, 0, len(datablock) - 1, calc_type)
         out = {
             "pmagpy_version": pmagpy_version(),
             "calculation_type": calc_type,
@@ -53,6 +55,7 @@ def gen_pca(args: argparse.Namespace) -> None:
                 "dec": result.get("specimen_dec"),
                 "inc": result.get("specimen_inc"),
                 "mad": result.get("specimen_mad"),
+                "dang": result.get("specimen_dang"),
                 "n": result.get("specimen_n"),
                 "direction_type": result.get("specimen_direction_type"),
             },

--- a/scripts/gen_pca.py
+++ b/scripts/gen_pca.py
@@ -1,0 +1,60 @@
+"""PCA (principal component analysis) fixture generator.
+
+See scripts/README.md for the input shape and the PmagPy `pmag.domean` notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from _fixture_common import (
+    FIXTURES_ROOT,
+    PCA_CALC_TYPES,
+    discover_inputs,
+    load_json,
+    output_path_for,
+    pmagpy_version,
+    require_pmagpy,
+    write_output,
+)
+
+
+def gen_pca(args: argparse.Namespace) -> None:
+    pmag = require_pmagpy()
+    inputs = discover_inputs(FIXTURES_ROOT / "pca")
+    if not inputs:
+        print("[pca] no *.input.json files yet; nothing to do")
+        return
+    for inp in inputs:
+        data = load_json(inp)
+        directions = data.get("directions") or []
+        calc_type = data.get("calculation_type", "DE-BFL")
+        if not directions:
+            print(f"[pca] {inp.name}: missing or empty 'directions'; skipping")
+            continue
+        if calc_type not in PCA_CALC_TYPES:
+            print(
+                f"[pca] {inp.name}: bad calculation_type {calc_type!r} "
+                f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
+            )
+            continue
+        # pmag.domean(data, start, end, calculation_type):
+        #   data         — list of [dec, inc, intensity] rows
+        #   start/end    — indices into data (inclusive)
+        #   calc type    — DE-BFL (free line), DE-BFL-A (anchored line), DE-BFP (plane)
+        # Returns specimen_dec, specimen_inc, specimen_mad, specimen_n,
+        # specimen_direction_type, center_of_mass, ...
+        # doprinc is NOT used: it doesn't return MAD and doesn't model anchored mode.
+        result = pmag.domean(directions, 0, len(directions) - 1, calc_type)
+        out = {
+            "pmagpy_version": pmagpy_version(),
+            "calculation_type": calc_type,
+            "principal": {
+                "dec": result.get("specimen_dec"),
+                "inc": result.get("specimen_inc"),
+                "mad": result.get("specimen_mad"),
+                "n": result.get("specimen_n"),
+                "direction_type": result.get("specimen_direction_type"),
+            },
+        }
+        write_output(output_path_for(inp), out, args.force, "pca")

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -20,6 +20,7 @@ See `scripts/README.md` for the input-file shape per topic and for the
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import sys
 from pathlib import Path
@@ -30,7 +31,14 @@ FIXTURES_ROOT = REPO_ROOT / "src" / "__tests__" / "fixtures"
 INPUT_SUFFIX = ".input.json"
 OUTPUT_SUFFIX = ".pmagpy.json"
 
+PCA_CALC_TYPES = {"DE-BFL", "DE-BFL-A", "DE-BFP"}
 
+
+class StubNotImplemented(Exception):
+    """Topic is registered in the CLI but has no generator yet."""
+
+
+@functools.lru_cache(maxsize=1)
 def require_pmagpy():
     try:
         from pmagpy import pmag  # type: ignore[import-not-found]
@@ -44,11 +52,15 @@ def require_pmagpy():
 
 
 def pmagpy_version() -> str:
+    # PmagPy doesn't reliably set __version__ on the package, so read the
+    # PyPI/installer-recorded version instead.
     try:
-        import pmagpy  # type: ignore[import-not-found]
-
-        return getattr(pmagpy, "__version__", "unknown")
+        from importlib.metadata import PackageNotFoundError, version
     except ImportError:
+        return "unknown"
+    try:
+        return version("pmagpy")
+    except PackageNotFoundError:
         return "unknown"
 
 
@@ -61,6 +73,14 @@ def discover_inputs(topic_dir: Path) -> list[Path]:
 def output_path_for(input_path: Path) -> Path:
     stem = input_path.name[: -len(INPUT_SUFFIX)]
     return input_path.parent / f"{stem}{OUTPUT_SUFFIX}"
+
+
+def load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        try:
+            return json.load(fh)
+        except json.JSONDecodeError as exc:
+            sys.exit(f"{path.relative_to(REPO_ROOT)}: invalid JSON — {exc}")
 
 
 def write_output(output_path: Path, data: dict, force: bool, label: str) -> bool:
@@ -82,8 +102,7 @@ def gen_fisher(args: argparse.Namespace) -> None:
         print("[fisher] no *.input.json files yet; nothing to do")
         return
     for inp in inputs:
-        with open(inp, encoding="utf-8") as fh:
-            data = json.load(fh)
+        data = load_json(inp)
         directions = data.get("directions") or []
         if not directions:
             print(f"[fisher] {inp.name}: missing or empty 'directions'; skipping")
@@ -94,13 +113,13 @@ def gen_fisher(args: argparse.Namespace) -> None:
         out = {
             "pmagpy_version": pmagpy_version(),
             "fisher_mean": {
-                "dec": result["dec"],
-                "inc": result["inc"],
-                "k": result["k"],
-                "a95": result["alpha95"],
+                "dec": result.get("dec"),
+                "inc": result.get("inc"),
+                "k": result.get("k"),
+                "a95": result.get("alpha95"),
                 "csd": result.get("csd"),
-                "n": result["n"],
-                "r": result["r"],
+                "n": result.get("n"),
+                "r": result.get("r"),
             },
         }
         write_output(output_path_for(inp), out, args.force, "fisher")
@@ -113,26 +132,35 @@ def gen_pca(args: argparse.Namespace) -> None:
         print("[pca] no *.input.json files yet; nothing to do")
         return
     for inp in inputs:
-        with open(inp, encoding="utf-8") as fh:
-            data = json.load(fh)
-        vectors = data.get("vectors") or []
-        anchored = bool(data.get("anchored", False))
-        if not vectors:
-            print(f"[pca] {inp.name}: missing or empty 'vectors'; skipping")
+        data = load_json(inp)
+        directions = data.get("directions") or []
+        calc_type = data.get("calculation_type", "DE-BFL")
+        if not directions:
+            print(f"[pca] {inp.name}: missing or empty 'directions'; skipping")
             continue
-        # pmag.doprinc: PCA on a block of [x, y, z] vectors.
-        result = pmag.doprinc(vectors)
+        if calc_type not in PCA_CALC_TYPES:
+            print(
+                f"[pca] {inp.name}: bad calculation_type {calc_type!r} "
+                f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
+            )
+            continue
+        # pmag.domean(data, start, end, calculation_type):
+        #   data         — list of [dec, inc, intensity] rows
+        #   start/end    — indices into data (inclusive)
+        #   calc type    — DE-BFL (free line), DE-BFL-A (anchored line), DE-BFP (plane)
+        # Returns specimen_dec, specimen_inc, specimen_mad, specimen_n,
+        # specimen_direction_type, center_of_mass, ...
+        # doprinc is NOT used: it doesn't return MAD and doesn't model anchored mode.
+        result = pmag.domean(directions, 0, len(directions) - 1, calc_type)
         out = {
             "pmagpy_version": pmagpy_version(),
-            "anchored": anchored,
+            "calculation_type": calc_type,
             "principal": {
-                "dec": result.get("dec"),
-                "inc": result.get("inc"),
-                "tau1": result.get("tau1"),
-                "tau2": result.get("tau2"),
-                "tau3": result.get("tau3"),
-                "MAD": result.get("MAD"),
-                "N": result.get("N"),
+                "dec": result.get("specimen_dec"),
+                "inc": result.get("specimen_inc"),
+                "mad": result.get("specimen_mad"),
+                "n": result.get("specimen_n"),
+                "direction_type": result.get("specimen_direction_type"),
             },
         }
         write_output(output_path_for(inp), out, args.force, "pca")
@@ -140,9 +168,9 @@ def gen_pca(args: argparse.Namespace) -> None:
 
 def gen_stub(name: str) -> Callable[[argparse.Namespace], None]:
     def gen(_args: argparse.Namespace) -> None:
-        sys.exit(
+        raise StubNotImplemented(
             f"[{name}] generator not yet implemented. "
-            f"Implement it when the corresponding test step lands and document "
+            f"Implement when the corresponding test step lands and document "
             f"the input schema in scripts/README.md."
         )
 
@@ -155,7 +183,7 @@ GENERATORS: dict[str, Callable[[argparse.Namespace], None]] = {
     "watson": gen_stub("watson"),
     "vgp": gen_stub("vgp"),
     "mcfadden": gen_stub("mcfadden"),
-    "fold-test": gen_stub("fold-test"),
+    "fold_test": gen_stub("fold_test"),
     "cutoff": gen_stub("cutoff"),
     "bootstrap": gen_stub("bootstrap"),
 }
@@ -179,21 +207,21 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.topic == "all":
-        any_failed = False
+        # Fail fast if PmagPy isn't installed — otherwise every implemented
+        # generator would print the install message in turn.
+        require_pmagpy()
         for name, fn in GENERATORS.items():
             print(f"\n=== {name} ===")
             try:
                 fn(args)
-            except SystemExit as exc:
-                # stubs raise SystemExit by design — keep going for the rest
-                code = exc.code
-                if code not in (None, 0):
-                    print(str(code) if isinstance(code, str) else f"exit code {code}")
-                    any_failed = True
-        if any_failed:
-            sys.exit(1)
+            except StubNotImplemented as exc:
+                print(str(exc))
+        # Stubs are expected absences, not failures: exit 0.
     else:
-        GENERATORS[args.topic](args)
+        try:
+            GENERATORS[args.topic](args)
+        except StubNotImplemented as exc:
+            sys.exit(str(exc))
 
 
 if __name__ == "__main__":

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -8,6 +8,9 @@ The Jest suite reads the committed `*.pmagpy.json` files at runtime — this
 script is **only** needed when adding or refreshing a fixture. CI never runs
 this script and the test suite has no Python dependency.
 
+Per-topic generators live in sibling `gen_<topic>.py` files; this file is the
+CLI entry point and dispatch table.
+
 Run from the repo root:
 
     python3 scripts/generate_fixtures.py fisher
@@ -20,150 +23,12 @@ See `scripts/README.md` for the input-file shape per topic and for the
 from __future__ import annotations
 
 import argparse
-import functools
-import json
 import sys
-from pathlib import Path
 from typing import Callable
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-FIXTURES_ROOT = REPO_ROOT / "src" / "__tests__" / "fixtures"
-INPUT_SUFFIX = ".input.json"
-OUTPUT_SUFFIX = ".pmagpy.json"
-
-PCA_CALC_TYPES = {"DE-BFL", "DE-BFL-A", "DE-BFP"}
-
-
-class StubNotImplemented(Exception):
-    """Topic is registered in the CLI but has no generator yet."""
-
-
-@functools.lru_cache(maxsize=1)
-def require_pmagpy():
-    try:
-        from pmagpy import pmag  # type: ignore[import-not-found]
-    except ImportError:
-        sys.exit(
-            "PmagPy is not installed.\n"
-            "Run:  pip install pmagpy\n"
-            "Then re-run this script."
-        )
-    return pmag
-
-
-def pmagpy_version() -> str:
-    # PmagPy doesn't reliably set __version__ on the package, so read the
-    # PyPI/installer-recorded version instead.
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-    except ImportError:
-        return "unknown"
-    try:
-        return version("pmagpy")
-    except PackageNotFoundError:
-        return "unknown"
-
-
-def discover_inputs(topic_dir: Path) -> list[Path]:
-    if not topic_dir.is_dir():
-        return []
-    return sorted(topic_dir.glob(f"*{INPUT_SUFFIX}"))
-
-
-def output_path_for(input_path: Path) -> Path:
-    stem = input_path.name[: -len(INPUT_SUFFIX)]
-    return input_path.parent / f"{stem}{OUTPUT_SUFFIX}"
-
-
-def load_json(path: Path) -> dict:
-    with open(path, encoding="utf-8") as fh:
-        try:
-            return json.load(fh)
-        except json.JSONDecodeError as exc:
-            sys.exit(f"{path.relative_to(REPO_ROOT)}: invalid JSON — {exc}")
-
-
-def write_output(output_path: Path, data: dict, force: bool, label: str) -> bool:
-    if output_path.exists() and not force:
-        rel = output_path.relative_to(REPO_ROOT)
-        print(f"[{label}] skip {rel} (exists; pass --force to overwrite)")
-        return False
-    with open(output_path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
-        fh.write("\n")
-    print(f"[{label}] wrote {output_path.relative_to(REPO_ROOT)}")
-    return True
-
-
-def gen_fisher(args: argparse.Namespace) -> None:
-    pmag = require_pmagpy()
-    inputs = discover_inputs(FIXTURES_ROOT / "fisher")
-    if not inputs:
-        print("[fisher] no *.input.json files yet; nothing to do")
-        return
-    for inp in inputs:
-        data = load_json(inp)
-        directions = data.get("directions") or []
-        if not directions:
-            print(f"[fisher] {inp.name}: missing or empty 'directions'; skipping")
-            continue
-        # pmag.fisher_mean: input is list of [dec, inc] pairs.
-        # Returns a dict with dec, inc, k, alpha95, csd, n, r.
-        result = pmag.fisher_mean(directions)
-        out = {
-            "pmagpy_version": pmagpy_version(),
-            "fisher_mean": {
-                "dec": result.get("dec"),
-                "inc": result.get("inc"),
-                "k": result.get("k"),
-                "a95": result.get("alpha95"),
-                "csd": result.get("csd"),
-                "n": result.get("n"),
-                "r": result.get("r"),
-            },
-        }
-        write_output(output_path_for(inp), out, args.force, "fisher")
-
-
-def gen_pca(args: argparse.Namespace) -> None:
-    pmag = require_pmagpy()
-    inputs = discover_inputs(FIXTURES_ROOT / "pca")
-    if not inputs:
-        print("[pca] no *.input.json files yet; nothing to do")
-        return
-    for inp in inputs:
-        data = load_json(inp)
-        directions = data.get("directions") or []
-        calc_type = data.get("calculation_type", "DE-BFL")
-        if not directions:
-            print(f"[pca] {inp.name}: missing or empty 'directions'; skipping")
-            continue
-        if calc_type not in PCA_CALC_TYPES:
-            print(
-                f"[pca] {inp.name}: bad calculation_type {calc_type!r} "
-                f"(expected one of {sorted(PCA_CALC_TYPES)}); skipping"
-            )
-            continue
-        # pmag.domean(data, start, end, calculation_type):
-        #   data         — list of [dec, inc, intensity] rows
-        #   start/end    — indices into data (inclusive)
-        #   calc type    — DE-BFL (free line), DE-BFL-A (anchored line), DE-BFP (plane)
-        # Returns specimen_dec, specimen_inc, specimen_mad, specimen_n,
-        # specimen_direction_type, center_of_mass, ...
-        # doprinc is NOT used: it doesn't return MAD and doesn't model anchored mode.
-        result = pmag.domean(directions, 0, len(directions) - 1, calc_type)
-        out = {
-            "pmagpy_version": pmagpy_version(),
-            "calculation_type": calc_type,
-            "principal": {
-                "dec": result.get("specimen_dec"),
-                "inc": result.get("specimen_inc"),
-                "mad": result.get("specimen_mad"),
-                "n": result.get("specimen_n"),
-                "direction_type": result.get("specimen_direction_type"),
-            },
-        }
-        write_output(output_path_for(inp), out, args.force, "pca")
+from _fixture_common import StubNotImplemented, require_pmagpy
+from gen_fisher import gen_fisher
+from gen_pca import gen_pca
 
 
 def gen_stub(name: str) -> Callable[[argparse.Namespace], None]:

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Generate PmagPy comparison fixtures for the PMTools Phase 1 test suite.
+
+For each `<name>.input.json` under `src/__tests__/fixtures/<topic>/`, runs the
+matching PmagPy routine and writes `<name>.pmagpy.json` next to it.
+
+The Jest suite reads the committed `*.pmagpy.json` files at runtime — this
+script is **only** needed when adding or refreshing a fixture. CI never runs
+this script and the test suite has no Python dependency.
+
+Run from the repo root:
+
+    python3 scripts/generate_fixtures.py fisher
+    python3 scripts/generate_fixtures.py all --force
+
+See `scripts/README.md` for the input-file shape per topic and for the
+"PmagPy disagrees with PMTools" investigation procedure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_ROOT = REPO_ROOT / "src" / "__tests__" / "fixtures"
+INPUT_SUFFIX = ".input.json"
+OUTPUT_SUFFIX = ".pmagpy.json"
+
+
+def require_pmagpy():
+    try:
+        from pmagpy import pmag  # type: ignore[import-not-found]
+    except ImportError:
+        sys.exit(
+            "PmagPy is not installed.\n"
+            "Run:  pip install pmagpy\n"
+            "Then re-run this script."
+        )
+    return pmag
+
+
+def pmagpy_version() -> str:
+    try:
+        import pmagpy  # type: ignore[import-not-found]
+
+        return getattr(pmagpy, "__version__", "unknown")
+    except ImportError:
+        return "unknown"
+
+
+def discover_inputs(topic_dir: Path) -> list[Path]:
+    if not topic_dir.is_dir():
+        return []
+    return sorted(topic_dir.glob(f"*{INPUT_SUFFIX}"))
+
+
+def output_path_for(input_path: Path) -> Path:
+    stem = input_path.name[: -len(INPUT_SUFFIX)]
+    return input_path.parent / f"{stem}{OUTPUT_SUFFIX}"
+
+
+def write_output(output_path: Path, data: dict, force: bool, label: str) -> bool:
+    if output_path.exists() and not force:
+        rel = output_path.relative_to(REPO_ROOT)
+        print(f"[{label}] skip {rel} (exists; pass --force to overwrite)")
+        return False
+    with open(output_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    print(f"[{label}] wrote {output_path.relative_to(REPO_ROOT)}")
+    return True
+
+
+def gen_fisher(args: argparse.Namespace) -> None:
+    pmag = require_pmagpy()
+    inputs = discover_inputs(FIXTURES_ROOT / "fisher")
+    if not inputs:
+        print("[fisher] no *.input.json files yet; nothing to do")
+        return
+    for inp in inputs:
+        with open(inp, encoding="utf-8") as fh:
+            data = json.load(fh)
+        directions = data.get("directions") or []
+        if not directions:
+            print(f"[fisher] {inp.name}: missing or empty 'directions'; skipping")
+            continue
+        # pmag.fisher_mean: input is list of [dec, inc] pairs.
+        # Returns a dict with dec, inc, k, alpha95, csd, n, r.
+        result = pmag.fisher_mean(directions)
+        out = {
+            "pmagpy_version": pmagpy_version(),
+            "fisher_mean": {
+                "dec": result["dec"],
+                "inc": result["inc"],
+                "k": result["k"],
+                "a95": result["alpha95"],
+                "csd": result.get("csd"),
+                "n": result["n"],
+                "r": result["r"],
+            },
+        }
+        write_output(output_path_for(inp), out, args.force, "fisher")
+
+
+def gen_pca(args: argparse.Namespace) -> None:
+    pmag = require_pmagpy()
+    inputs = discover_inputs(FIXTURES_ROOT / "pca")
+    if not inputs:
+        print("[pca] no *.input.json files yet; nothing to do")
+        return
+    for inp in inputs:
+        with open(inp, encoding="utf-8") as fh:
+            data = json.load(fh)
+        vectors = data.get("vectors") or []
+        anchored = bool(data.get("anchored", False))
+        if not vectors:
+            print(f"[pca] {inp.name}: missing or empty 'vectors'; skipping")
+            continue
+        # pmag.doprinc: PCA on a block of [x, y, z] vectors.
+        result = pmag.doprinc(vectors)
+        out = {
+            "pmagpy_version": pmagpy_version(),
+            "anchored": anchored,
+            "principal": {
+                "dec": result.get("dec"),
+                "inc": result.get("inc"),
+                "tau1": result.get("tau1"),
+                "tau2": result.get("tau2"),
+                "tau3": result.get("tau3"),
+                "MAD": result.get("MAD"),
+                "N": result.get("N"),
+            },
+        }
+        write_output(output_path_for(inp), out, args.force, "pca")
+
+
+def gen_stub(name: str) -> Callable[[argparse.Namespace], None]:
+    def gen(_args: argparse.Namespace) -> None:
+        sys.exit(
+            f"[{name}] generator not yet implemented. "
+            f"Implement it when the corresponding test step lands and document "
+            f"the input schema in scripts/README.md."
+        )
+
+    return gen
+
+
+GENERATORS: dict[str, Callable[[argparse.Namespace], None]] = {
+    "fisher": gen_fisher,
+    "pca": gen_pca,
+    "watson": gen_stub("watson"),
+    "vgp": gen_stub("vgp"),
+    "mcfadden": gen_stub("mcfadden"),
+    "fold-test": gen_stub("fold-test"),
+    "cutoff": gen_stub("cutoff"),
+    "bootstrap": gen_stub("bootstrap"),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "topic",
+        choices=list(GENERATORS) + ["all"],
+        help="fixture topic to (re)generate, or 'all' for every implemented topic",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing .pmagpy.json files",
+    )
+    args = parser.parse_args()
+
+    if args.topic == "all":
+        any_failed = False
+        for name, fn in GENERATORS.items():
+            print(f"\n=== {name} ===")
+            try:
+                fn(args)
+            except SystemExit as exc:
+                # stubs raise SystemExit by design — keep going for the rest
+                code = exc.code
+                if code not in (None, 0):
+                    print(str(code) if isinstance(code, str) else f"exit code {code}")
+                    any_failed = True
+        if any_failed:
+            sys.exit(1)
+    else:
+        GENERATORS[args.topic](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Phase 1 Step 0.4 from `.claude/development-roadmap/01-testing.md`.
- Adds `scripts/generate_fixtures.py` and `scripts/README.md` per the roadmap's Oracle Strategy ("Secondary: PmagPy parity").

## What it does
- Reads `<name>.input.json` files under `src/__tests__/fixtures/<topic>/`, runs the matching PmagPy routine, writes `<name>.pmagpy.json` next to each input.
- The Jest suite reads the committed `*.pmagpy.json` files at test time. **CI never runs this script.** Python is not a test-time dependency.

## Implemented out of the gate
| Topic | Input shape | PmagPy routine |
|---|---|---|
| `fisher` | `{ "directions": [[D, I], …] }` | `pmag.fisher_mean` |
| `pca` | `{ "vectors": [[x, y, z], …], "anchored": false }` | `pmag.doprinc` |

These are the first topics touched in Phase 1 Steps 1–2.

## Stubs (filled in as Phase 1 progresses)
`watson`, `vgp`, `mcfadden`, `fold-test`, `cutoff`, `bootstrap` are CLI-registered but exit 1 with a "not yet implemented" message. README documents the procedure for filling them in.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('scripts/generate_fixtures.py').read())"` — syntax clean
- [x] `python3 scripts/generate_fixtures.py --help` — argparse + docstring render correctly
- [x] `npm run verify` clean
- [x] `npm test` — 4/4 (no JS changes; sanity check that nothing got broken)
- [ ] Smoke-test against PmagPy locally once one of us actually `pip install pmagpy`s

The script's PmagPy code paths can't be smoke-tested without PmagPy installed. They will be exercised the first time Step 1 lands a Fisher fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)