### PR TITLE
docs(roadmap): incorporate fixture-sweep findings into Phase 1

### DIFF
--- a/.claude/development-roadmap/01-testing.md
+++ b/.claude/development-roadmap/01-testing.md
@@ -208,7 +208,7 @@ src/__tests__/fixtures/
 
    Goal: representative coverage of every dialect a parser branches on, **not** bulk import. The full archive stays out of the repo (gitignored at `/test-data/potential-data`).
 9. Format-specific fixture sourcing:
-   - `.rs3`: real files now in archive (Polar Ural, Crimea — see Step 0.6 sweep notes). Synthetic-from-spec still required to cover `P1`/`P3` orientation branches (3, 9, 12) — all real files have `P1=6 P3=6`.
+   - `.rs3`: real files now in archive (Polar Ural, Crimea — see "Discovered During Fixture Sweep" section below). Synthetic-from-spec still required to cover `P1`/`P3` orientation branches (3, 9, 12) — all real files have `P1=6 P3=6`.
    - `.mdir`: out-of-scope per Non-Goals — no fixtures, no test suite, parser excluded from the coverage gate.
    - `.csv` and `.xlsx` (real): no real files exist on disk because users export them on demand from PMTools itself. Generate them via a Playwright-driven export run: load real PMD/DIR data, click through the export menu, capture the produced files, drop into `parsers/<format>/real/`. This is genuine "real" data — produced by the actual app, not synthesized from the format spec.
 
@@ -286,7 +286,7 @@ Per-parser coverage target: 100% lines, 100% branches. If a branch can't be reac
 3. `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon` — real CSVs produced by Playwright-driven PMTools export of real PMD/DIR data (see Step 0 item 9) + synthetic separators (comma, semicolon), quoted fields, empty cells, encoding variants.
 4. `parserXLSX_PMD`, `parserXLSX_DIR`, `parserXLSX_SitesLatLon` — real `.xlsx` produced by Playwright-driven PMTools export + synthetic generated via the `xlsx` lib (multi-sheet, empty sheet, formula cells, date cells, hidden columns). Legacy `.xls` (Excel 97-2003 binary) is out-of-scope per Non-Goals.
 5. `parserPMM` — real `.pmm` (`season1_north.pmm`, `season1_south.pmm`, `season2_extra.pmm`, `exampleDIR.pmm`, plus archive PMMs with `Fisher` code and dashed IDs) + synthetic.
-6. `parserSQUID` — real `.squid` files in archive (currently only `406c.squid` — request additional samples covering `metadata.a < 90` branch) + synthetic edge cases including the throws-on-empty/invalid paths.
+6. `parserSQUID` — real `.squid` files in archive (`406c.squid`, `70.squid` — the latter paired with `70.pmd` as the golden output for the D5 fix; request additional samples covering `metadata.a < 90` branch) + synthetic edge cases including the throws-on-empty/invalid paths and a synthetic ARM-block fixture that locks the truncation behavior independently of `70.squid`.
 7. `parserRS3` — real files from 2012 Polar Ural + 2013 Crimea archives (all use `P1=6 P3=6`); synthetic-from-spec required to cover `P1`/`P3` ∈ {3, 9, 12} orientation correction branches.
 8. `parserMDIR` — out-of-scope per Non-Goals. No test suite, no fixtures, parser excluded from coverage via `coveragePathIgnorePatterns`.
 
@@ -397,13 +397,15 @@ Manual verification of scientific findings:
 
 ## Discovered During Fixture Sweep (2026-05-02)
 
-Real-file investigation of the 2000-2014 archive surfaced four parser issues. Each gets its own `fix(science):` commit during Step 4 with the offending real file as the regression fixture.
+Real-file investigation of the 2000-2014 archive surfaced five parser issues. Each gets its own `fix(science):` commit during Step 4 with the offending real file as the regression fixture.
 
-### D1. `parserDIR` — Mac classic CR-only line endings break parsing
+### D1. All parsers — Mac classic CR-only line endings break parsing
 
 The archive file `2013-Kola/.../component means.dir` uses `\r`-only line terminators (no `\n`). The parser splits lines via `new RegExp('\r?\n')` which **does not match** a lone `\r`, so the entire file collapses to a single string and parsing returns garbage.
 
-**Fix**: change the line-split regex to `/\r\n|\r|\n/` (handle CRLF, CR, LF independently). Regression test: parse the archive file, assert N>0 interpretations and matching expected values.
+The bug is **not parserDIR-specific**: every parser uses the same `new RegExp('\r?\n')` regex (`parserPMD`, `parserDIR`, `parserPMM`, `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon`, `parserMDIR`, `parserRS3`, `parserSQUID` — 9 parsers total). Only `.dir` had a CR-only file in the archive, but the same input class would break any of the others.
+
+**Fix**: change the line-split regex to `/\r\n|\r|\n/` in **all 9 parsers** in a single commit (CRLF, CR, LF handled independently). Regression test for parserDIR uses the archive file and asserts N>0 interpretations with matching expected values; other parsers get a synthetic CR-only fixture each — single-line generator, low cost, locks the regression for the entire parser surface.
 
 **Severity**: parser silently produces wrong output on a class of legitimate legacy files. High-priority `fix(science):`.
 
@@ -441,6 +443,24 @@ Archive file `231-291.pmm` contains `STEPRANGE = "site avg"`. After `params = li
 
 **Severity**: cosmetic. Not a `fix(science):`. A behavior-locking test only.
 
+### D5. `parserSQUID` — AF field values are in Oersted; ARM block must be truncated
+
+The archive file `2bar/70.squid` contains AF lines with values `100, 150, 200, ..., 900`. These are **Oersted**, not millitesla. Physical AF demagnetization caps at ~200 mT, so triple-digit values interpreted as mT are unphysical. The corresponding PMD file produced by R.V. Veselovsky's pre-PMTools converter (`70.pmd`) has `M010, M015, M020, ..., M090` — confirming the original `/10` conversion (1 mT = 10 Oe) was correct.
+
+`parserSQUID.ts:53-58` actively removes this conversion with the comment `// почему-то так было в коде конвертера у РВ, но по факту это неправильно` — a regression introduced when the parser was rewritten. Confirmed wrong by R.V. Veselovsky (domain authority, original converter author) on 2026-05-09.
+
+The same archive file also exposes a second issue: after the AF demagnetization block ends, an ARM-acquisition section begins (`ARM  1`) followed by AF-of-ARM lines. These are a measurement-protocol artifact, **not** data PMTools should display or analyze. R.V. confirmed on 2026-05-09: silently truncate the `ARM` line and every line below it.
+
+**Fix** (single `fix(science):` commit):
+1. **Restore `/10` for AF** lines so `AF 100` → `M10`, `AF 900` → `M90`.
+2. **Truncate at ARM** — when a line starts with `ARM`, drop it and all subsequent lines without warning.
+3. **Compare first two characters** (`line.slice(0, 2)`) so `AF` and `ARM` are distinguishable. Free side-effect: the bare `AF` line (NRM, no field value) currently produces `M0` because `stepSymbol === 'N'` never matches first character `'A'`. With the two-char check this resolves correctly to step `NRM`.
+4. **Remove the misleading comment** at line 54 — the original RV converter logic was correct.
+
+**Severity**: HIGH. Numeric data corruption — every AF demagnetization step displayed in PMTools after a SQUID import currently shows the wrong field value (10× too large). Silently produces wrong PCA fits on real `.squid` input. Priority above D1.
+
+**Regression fixture**: `2bar/70.squid` (input) + `2bar/70.pmd` (expected output — golden produced by RV's converter). Single fixture verifies all three behaviors: Oersted→mT conversion, ARM truncation, NRM step name. A small synthetic fixture also covers ARM truncation independently of the real fixture so the locked behavior is unambiguous.
+
 ## Risks
 
 | Risk | Mitigation |
@@ -450,6 +470,7 @@ Archive file `231-291.pmm` contains `STEPRANGE = "site avg"`. After `params = li
 | Extraction refactors silently change behavior | Golden-master snapshot BEFORE refactoring, then refactor, then assert snapshot still matches. |
 | `.rs3` real files all share `P1=6 P3=6` (other orientation branches uncovered) | Synthetic fixture from spec covers P1/P3 ∈ {3, 9, 12} branches. Real files cover the dominant case. |
 | Archive files surface parser dialect surprises (CR-only line endings, non-UTF-8 encoding, NRM-prefixed steps without `T`/`M` letters) | Each surprise becomes a `fix(science):` commit with the offending real file as regression test. See "Discovered During Fixture Sweep" section. |
+| In-code commentary contradicts domain authority (e.g. `// по факту это неправильно` overriding correct logic from the original SQUID→PMD converter — see D5) | Treat the domain expert as overriding any uncited in-code commentary. Confirmation is recorded in the relevant `parsers/<format>/SOURCE.md` and in this section with the date and the expert's name. |
 | 100% coverage gate is hard for parsers with rarely-triggered branches | Either build the synthetic input that triggers the branch, or delete the branch as unreachable. Both are acceptable; "exempt" is not. |
 | Scope creep into Phase 4 (full extraction) | Strict boundary: only the 3 named tangled files get extracted here. All other extractions wait for Phase 4. |
 | Thesis formula differs from live code | Treat as a bug in the code — the thesis is the spec. Fix in a `fix(science):` commit unless there is a documented reason the code intentionally deviates. |

--- a/.claude/development-roadmap/01-testing.md
+++ b/.claude/development-roadmap/01-testing.md
@@ -20,6 +20,9 @@ Establish a test suite that:
 - No UI component tests (Phase 2).
 - No tests for Redux slices in their current shape — they will be replaced in Phase 6.
 - No migration to Vitest — Jest ships with `react-scripts` and is ready today. The Jest → Vitest migration happens in Phase 6 and is trivial (~95% API compatibility).
+- **No legacy XLS support (Excel 97-2003 binary `.xls`).** PMTools was created in 2021 — pre-2021 files are not in scope, ever. PMTools reads/writes only modern OpenXML `.xlsx` produced by PMTools itself or by tooling explicitly conforming to PMTools schema. Legacy `.xls` files encountered in user archives are out-of-scope and never become test fixtures.
+- **No `.jr6` parser.** In 3 years of PMTools no user has requested it; users with JR6 instruments convert to the supported formats. We will not introduce a JR6 parser in Phase 1 or any later phase unless real demand emerges.
+- **No `.mdir` test suite.** Even synthetic — the format is dead, no real files exist in any current archive, and the parser is scheduled for removal in a future cleanup. `parserMDIR.ts` is excluded from the Phase 1 100% coverage gate; coverage tooling treats it as `coveragePathIgnorePatterns`.
 
 ## Oracle Strategy
 
@@ -197,10 +200,17 @@ src/__tests__/fixtures/
 5. Scaffold `src/__tests__/fixtures/` tree with empty `SOURCE.md` files per section. Each parser fixture directory has both `real/` and `synthetic/` subdirectories from day one.
 6. Capture coverage baseline before any new tests land: `npm test -- --watchAll=false --coverage` → save to `.claude/development-roadmap/notes/phase-1-coverage-baseline.txt`. This is the floor; the phase exit requires this coverage to grow to 100% for statistics + parsers + converters.
 7. Copy `src/assets/PMTools_how_to_use.pdf` formulas into a cheatsheet at `src/__tests__/fixtures/THESIS_FORMULAS.md` so test authors can cite them without reopening the PDF.
-8. **Gather real fixtures**: copy every real file matching each parser's format from `test-data/`, `test-data/v2.6.*/`, `src/assets/examples/`, `.claude/issues/*` into the matching `parsers/<format>/real/` directory. Then ask Ivan for any additional private samples (target 3–11 real files per format).
+8. **Gather real fixtures**: copy a representative subset (3–8 per format) of real files from:
+   - `test-data/` and `test-data/v2.6.*/` regression directories
+   - `src/assets/examples/`
+   - `test-data/potential-data/` — large multi-year archive of expedition data (gitignored locally; Ivan curates which files migrate to `real/`). Sweep performed 2026-05-02 surfaced multiple parser bugs documented in "Discovered During Fixture Sweep" below.
+   - Future user-reported tickets when they appear.
+
+   Goal: representative coverage of every dialect a parser branches on, **not** bulk import. The full archive stays out of the repo (gitignored at `/test-data/potential-data`).
 9. Format-specific fixture sourcing:
-   - `.rs3`: write a synthetic file from the format spec **first** (unblocks the parser test suite), then add real files when sourced. Do not block the phase on a real `.rs3`.
-   - `.mdir`: deprecated; build synthetic from spec to lock current behavior, mark legacy in `SOURCE.md`. No real-file requirement.
+   - `.rs3`: real files now in archive (Polar Ural, Crimea — see Step 0.6 sweep notes). Synthetic-from-spec still required to cover `P1`/`P3` orientation branches (3, 9, 12) — all real files have `P1=6 P3=6`.
+   - `.mdir`: out-of-scope per Non-Goals — no fixtures, no test suite, parser excluded from the coverage gate.
+   - `.csv` and `.xlsx` (real): no real files exist on disk because users export them on demand from PMTools itself. Generate them via a Playwright-driven export run: load real PMD/DIR data, click through the export menu, capture the produced files, drop into `parsers/<format>/real/`. This is genuine "real" data — produced by the actual app, not synthesized from the format spec.
 
 ## Extraction Refactors (before writing tests for these modules)
 
@@ -250,7 +260,7 @@ Each gets thesis formula tests + 2–3 PmagPy parity cases + property-based test
 
 ### Step 2 — Testable-with-fixtures statistics
 
-1. **`calculatePCA_pmd` — HIGHEST PRIORITY**. Core of the PCA page. Tests must cover thesis formulas (1.1) vector MAD, (1.2) great-circle MAD, (1.3) covariance matrix H. Include regression case for the v2.6.3 MAD=0 bug fix (fixture captured from `test-data/v2.6.3/`).
+1. **`calculatePCA_pmd` — HIGHEST PRIORITY**. Core of the PCA page. Tests must cover thesis formulas (1.1) vector MAD, (1.2) great-circle MAD, (1.3) covariance matrix H.
 2. `calculatePCA_dir`.
 3. `calculateFisherMean` (IDirData wrapper).
 4. `calculateMcFaddenCombineMean` — McFadden 1988.
@@ -273,12 +283,12 @@ Per-parser coverage target: 100% lines, 100% branches. If a branch can't be reac
 
 1. `parserPMD` — every real `.pmd` we have + full synthetic matrix (empty, header-only, single-step, BOM, CRLF/LF, Russian decimal comma, Windows-1251, trailing whitespace, extreme numeric values, malformed shapes).
 2. `parserDIR` — every real `.dir` (including `field_batch.dir`, `sample.dir`, `malformed.dir`, `invalid_rows.dir`, `all_invalid.dir`) + full synthetic matrix including paired-G variant.
-3. `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon` — real CSVs from `test-data/lab_results.csv` and any others + synthetic separators (comma, semicolon), quoted fields, empty cells, encoding variants.
-4. `parserXLSX_PMD`, `parserXLSX_DIR`, `parserXLSX_SitesLatLon` — real `.xlsx` files Ivan provides + synthetic generated via `xlsx` lib (multi-sheet, empty sheet, formula cells, date cells, hidden columns).
-5. `parserPMM` — real `.pmm` (`season1_north.pmm`, `season1_south.pmm`, `season2_extra.pmm`, `exampleDIR.pmm`) + synthetic.
-6. `parserSQUID` — real `.squid` from `test-data/406c.squid` and `.claude/issues/*` (`a11-19.squid`, `10bg136b.squid`, `406c.squid`) + synthetic edge cases including the throws-on-empty/invalid paths.
-7. `parserRS3` — synthetic-from-spec covers all branches (unblocks the test suite); real files added to `real/` as soon as they're sourced. Both layers are required for this parser to be considered tested.
-8. `parserMDIR` — deprecated; synthetic-only test suite that locks current behavior so the parser can be safely removed in a future cleanup. Document the legacy status in `SOURCE.md`.
+3. `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon` — real CSVs produced by Playwright-driven PMTools export of real PMD/DIR data (see Step 0 item 9) + synthetic separators (comma, semicolon), quoted fields, empty cells, encoding variants.
+4. `parserXLSX_PMD`, `parserXLSX_DIR`, `parserXLSX_SitesLatLon` — real `.xlsx` produced by Playwright-driven PMTools export + synthetic generated via the `xlsx` lib (multi-sheet, empty sheet, formula cells, date cells, hidden columns). Legacy `.xls` (Excel 97-2003 binary) is out-of-scope per Non-Goals.
+5. `parserPMM` — real `.pmm` (`season1_north.pmm`, `season1_south.pmm`, `season2_extra.pmm`, `exampleDIR.pmm`, plus archive PMMs with `Fisher` code and dashed IDs) + synthetic.
+6. `parserSQUID` — real `.squid` files in archive (currently only `406c.squid` — request additional samples covering `metadata.a < 90` branch) + synthetic edge cases including the throws-on-empty/invalid paths.
+7. `parserRS3` — real files from 2012 Polar Ural + 2013 Crimea archives (all use `P1=6 P3=6`); synthetic-from-spec required to cover `P1`/`P3` ∈ {3, 9, 12} orientation correction branches.
+8. `parserMDIR` — out-of-scope per Non-Goals. No test suite, no fixtures, parser excluded from coverage via `coveragePathIgnorePatterns`.
 
 ### Step 5 — Converters (round-trip tests)
 
@@ -351,6 +361,7 @@ Phase 1 is complete when all of:
 ### Files to leave alone
 - `src/components/`, `src/pages/`, `src/App/` — UI tested in Phase 2.
 - `src/services/reducers/` — Redux slices will be replaced in Phase 6.
+- `src/utils/files/parsers/parserMDIR.ts` — out-of-scope per Non-Goals; excluded from the 100% coverage gate via `coveragePathIgnorePatterns` in the Jest config / `package.json`.
 
 ## Reused Existing Code
 
@@ -384,6 +395,52 @@ Manual verification of scientific findings:
 - Review any `fix(science):` commits with a domain expert.
 - Cross-check at least 3 PmagPy-parity fixtures by hand against the thesis formulas.
 
+## Discovered During Fixture Sweep (2026-05-02)
+
+Real-file investigation of the 2000-2014 archive surfaced four parser issues. Each gets its own `fix(science):` commit during Step 4 with the offending real file as the regression fixture.
+
+### D1. `parserDIR` — Mac classic CR-only line endings break parsing
+
+The archive file `2013-Kola/.../component means.dir` uses `\r`-only line terminators (no `\n`). The parser splits lines via `new RegExp('\r?\n')` which **does not match** a lone `\r`, so the entire file collapses to a single string and parsing returns garbage.
+
+**Fix**: change the line-split regex to `/\r\n|\r|\n/` (handle CRLF, CR, LF independently). Regression test: parse the archive file, assert N>0 interpretations and matching expected values.
+
+**Severity**: parser silently produces wrong output on a class of legitimate legacy files. High-priority `fix(science):`.
+
+### D2. `parserRS3` — file encoding handling for non-UTF-8 sources
+
+All 285 RS3 files in the archive are ISO-8859-1 (Latin-1). The parser's `slice(start, end)` operates on a JS string assumed to be already-decoded. If the upstream FileReader was invoked with the wrong encoding, the `°` byte (0xB0) in `Step[°C]` headers and elsewhere becomes `U+FFFD` — single character, so column offsets do not shift, but downstream consumers receive corrupt step-name strings.
+
+**Fix**: detect ISO-8859-1 / Windows-1251 in the FileReader pipeline (via byte-pattern heuristic on first 1KB or trial-decode comparison) and decode appropriately before handing to the parser. Regression test: parse one Polar Ural RS3, assert step names render as `Step[°C]` not `Step[?C]`.
+
+**Severity**: cosmetic for now (column offsets survive replacement-character substitution because U+FFFD is one code unit). Becomes severity-high if any future parser uses 0xB0 as a delimiter.
+
+### D3. `parserPMD` — `demagType` fixed by first valid line; cannot detect step-only or NRM-prefixed files
+
+The archive contains 23 PMD files (Crimea 2013) with this shape:
+```
+NRM  ... data ...
+90°C ... data ...
+150°C ... data ...
+```
+And 66 PMD files (Polar Ural 2012) with steps like `20`, `60`, `120` (no letter prefix at all).
+
+`parserPMD.ts` lines 64–69 set `demagType` from `line.slice(0, 1)` of the first valid step line, then never re-evaluates. For all 89 of these files, `demagType` becomes `undefined` and stays that way — the user sees no thermal/AF indication in the UI even though the data clearly shows thermal demagnetization.
+
+**Fix**: two-part.
+1. **Parser fix** (`fix(science):`) — scan the entire steps block for `°C` / temperature-shaped step names AND `mT`-shaped names; infer thermal vs AF from the dominant pattern, not the first-row prefix.
+2. **UX warning** (`feat(parser):` or scoped to Phase 2 UX work) — when the parser sees a file it cannot classify confidently, show a non-blocking warning on file load: explicitly explain "PMTools could not infer demagnetization type from this file; the demag column will be empty. Possible reasons: …". Wording must be aimed at scientists, not engineers — say what's missing in their terms (`T`/`M` step prefix or `°C`/`mT` unit suffix).
+
+**Severity**: medium. Doesn't corrupt numeric data, but degrades UX and breaks downstream filters that key off `demagType`.
+
+### D4. `parserPMM` — `replace(/\s+/g, '')` collapses internal whitespace in fields
+
+Archive file `231-291.pmm` contains `STEPRANGE = "site avg"`. After `params = line.replace(/\s+/g, '').split(',')`, the field becomes `siteavg` — the space is silently dropped.
+
+**Decision**: leave as-is. This has been current behavior since v1.x; users who export with this convention have always seen the collapsed form. Document as expected behavior in `parsers/pmm/SOURCE.md` and lock with a regression test that asserts `stepRange === "siteavg"` on this fixture.
+
+**Severity**: cosmetic. Not a `fix(science):`. A behavior-locking test only.
+
 ## Risks
 
 | Risk | Mitigation |
@@ -391,7 +448,8 @@ Manual verification of scientific findings:
 | PmagPy produces different output than PMTools or the thesis formula on a real file | Investigate every delta. Either PMTools has a bug (commit as `fix(science):`) or different documented convention (note in `SOURCE.md`). |
 | Bootstrap tests flaky due to RNG | Mandatory seeded **integer** PRNG in all bootstrap tests. No `Math.random()` directly. |
 | Extraction refactors silently change behavior | Golden-master snapshot BEFORE refactoring, then refactor, then assert snapshot still matches. |
-| `.rs3` real file missing | Synthetic fixture from spec unblocks the parser test suite immediately. Real files added to `real/` subdir as soon as sourced — phase does not wait. |
+| `.rs3` real files all share `P1=6 P3=6` (other orientation branches uncovered) | Synthetic fixture from spec covers P1/P3 ∈ {3, 9, 12} branches. Real files cover the dominant case. |
+| Archive files surface parser dialect surprises (CR-only line endings, non-UTF-8 encoding, NRM-prefixed steps without `T`/`M` letters) | Each surprise becomes a `fix(science):` commit with the offending real file as regression test. See "Discovered During Fixture Sweep" section. |
 | 100% coverage gate is hard for parsers with rarely-triggered branches | Either build the synthetic input that triggers the branch, or delete the branch as unreachable. Both are acceptable; "exempt" is not. |
 | Scope creep into Phase 4 (full extraction) | Strict boundary: only the 3 named tangled files get extracted here. All other extractions wait for Phase 4. |
 | Thesis formula differs from live code | Treat as a bug in the code — the thesis is the spec. Fix in a `fix(science):` commit unless there is a documented reason the code intentionally deviates. |

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ yarn-error.log*
 .claude/issues/
 .claude/settings.json
 .claude/settings.local.json
+
+# Real-data archive used to source Phase 1 parser fixtures.
+# Ivan curates which files migrate to src/__tests__/fixtures/parsers/<format>/real/.
+# The full archive (404 files across 2011-2014 expedition data) stays out of the repo.
+/test-data/potential-data


### PR DESCRIPTION
## Summary
Real-file investigation of `test-data/potential-data/` (404 files across 2011-2014 archives — France, Polar Ural, Crimea, Kola, Siberia) surfaced four parser issues and three policy decisions that need to land in the Phase 1 roadmap **before** real fixtures are committed.

## New section: "Discovered During Fixture Sweep"
Four follow-up items. Each becomes a `fix(science):` commit during Step 4 with the offending real archive file as the regression fixture.

| # | Issue | Severity | Decision |
|---|---|---|---|
| **D1** | `parserDIR` breaks on Mac CR-only line endings (`component means.dir`) | High — silent garbage output | Fix regex `\r?\n` → `/\r\n\|\r\|\n/` |
| **D2** | `parserRS3` ISO-8859 input read as UTF-8 — currently cosmetic only | Medium | Encoding-aware FileReader |
| **D3** | `parserPMD` `demagType` fixed by first line, never re-evaluated. Affects **89** archive files (Polar Ural numeric-only steps, Crimea NRM-then-°C) | Medium | Two-part fix: parser scans whole steps block + non-blocking UX warning at file load |
| **D4** | `parserPMM` collapses internal whitespace via `replace(/\s+/g, '')` | Cosmetic | Leave as-is, lock with regression test |

## Three policy additions to Non-Goals
- **No legacy XLS** (Excel 97-2003 binary). PMTools was created in 2021 — pre-2021 files are out-of-scope, ever.
- **No JR6 parser.** 3 years, zero user requests.
- **No MDIR test suite** (even synthetic). Format is dead. `parserMDIR.ts` excluded from the 100% coverage gate via `coveragePathIgnorePatterns`.

## Step 4 changes
- CSV/XLSX real fixtures: produced by **Playwright-driven export** from PMTools with real PMD/DIR data — these are genuine real exports, not synthesized.
- `parserSQUID`: still needs samples covering `metadata.a < 90` branch.
- `parserRS3`: real files cover the dominant `P1=6 P3=6` orientation; synthetic-from-spec covers branches 3, 9, 12.
- Removed obsolete v2.6.3 MAD=0 regression mention from Step 2 — fixed in `131cd8b`.

## Test plan
- [x] Doc-only PR — no source changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)