### PR TITLE
fix(science): unified line-ending regex across all 9 parsers (D1)

### DIFF
--- a/.claude/development-roadmap/01-testing.md
+++ b/.claude/development-roadmap/01-testing.md
@@ -399,15 +399,21 @@ Manual verification of scientific findings:
 
 Real-file investigation of the 2000-2014 archive surfaced five parser issues. Each gets its own `fix(science):` commit during Step 4 with the offending real file as the regression fixture.
 
-### D1. All parsers — Mac classic CR-only line endings break parsing
+### D1. All parsers — Mac classic CR-only line endings break parsing ✅ FIXED
 
-The archive file `2013-Kola/.../component means.dir` uses `\r`-only line terminators (no `\n`). The parser splits lines via `new RegExp('\r?\n')` which **does not match** a lone `\r`, so the entire file collapses to a single string and parsing returns garbage.
+**Status**: fixed. Severity at discovery: high (parsers silently produced wrong output on a class of legitimate legacy files). The archive file `2013-Kola/.../component means.dir` uses `\r`-only line terminators (no `\n`). The old regex `new RegExp('\r?\n')` did not match a lone `\r`, so the entire file collapsed to a single string and parsing returned garbage.
 
-The bug is **not parserDIR-specific**: every parser uses the same `new RegExp('\r?\n')` regex (`parserPMD`, `parserDIR`, `parserPMM`, `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon`, `parserMDIR`, `parserRS3`, `parserSQUID` — 9 parsers total). Only `.dir` had a CR-only file in the archive, but the same input class would break any of the others.
+The bug was **not parserDIR-specific**: every parser used the same regex (`parserPMD`, `parserDIR`, `parserPMM`, `parserCSV_PMD`, `parserCSV_DIR`, `parserCSV_SitesLatLon`, `parserMDIR`, `parserRS3`, `parserSQUID` — 9 parsers total). Only `.dir` had a CR-only file in the archive, but the same input class would have broken any of the others.
 
-**Fix**: change the line-split regex to `/\r\n|\r|\n/` in **all 9 parsers** in a single commit (CRLF, CR, LF handled independently). Regression test for parserDIR uses the archive file and asserts N>0 interpretations with matching expected values; other parsers get a synthetic CR-only fixture each — single-line generator, low cost, locks the regression for the entire parser surface.
+**What landed in the fix:**
+- Replaced the regex with `/\r\n|\r|\n/` in **all 9 parsers** in one commit. CRLF, CR, and LF are matched independently as line terminators.
+- `parserDIR` regression test (`src/utils/files/__tests__/parserDIR.test.ts`) decomposes into:
+  1. Synthetic CR-only file built from the standard parserDIR column layout — asserts exact field values (label, code, Dgeo, Igeo, gcNormal) for 3 interpretations + back-compat with CRLF and LF.
+  2. The real archive file `kola2013_repG_macCR_component_means.dir` — asserts the file splits into 17 raw lines and the parser walks them individually (the file's non-standard column layout is a separate concern, see follow-up below).
 
-**Severity**: parser silently produces wrong output on a class of legitimate legacy files. High-priority `fix(science):`.
+**Pending follow-up** (separate Phase 1 fix): `kola2013_repG_macCR_component_means.dir` uses a non-standard `rep G`/`rep S`/`rep G&S` column layout that doesn't match the slice positions in `parserDIR`. Even after D1, the parser's columns land on the wrong fields for this file. Tracked in `parsers/dir/README.md` Pending follow-ups; will be addressed when `parserDIR` gets format-flexibility work in Phase 1 Step 4 or as a separate `fix(science):`.
+
+Other parsers will get synthetic CR-only fixtures during Step 4 to lock the regression on their full surface.
 
 ### D2. `parserRS3` — file encoding handling for non-UTF-8 sources
 

--- a/src/__tests__/fixtures/parsers/dir/README.md
+++ b/src/__tests__/fixtures/parsers/dir/README.md
@@ -1,4 +1,4 @@
-# fixtures/parsers/dir — SOURCE
+# fixtures/parsers/dir — README
 
 Fixtures for `parserDIR` (`.dir` format — directional statistics file).
 
@@ -11,12 +11,23 @@ Fixtures for `parserDIR` (`.dir` format — directional statistics file).
 
 | Filename | Origin | Edge cases covered |
 |---|---|---|
-| `kola2013_repG_macCR_component_means.dir` | `test-data/potential-data/2000-2014-ARCHIVE/2013-Kola/mag/T/interpret/MiBa/component means.dir` (author: M. Bazhenov, 2013) | **D1 regression** — Mac classic CR-only line endings (no `\n`). Current parser regex `\r?\n` does not match a lone `\r`, so the file collapses to a single line and parsing returns garbage. Same input class would break all 9 parsers. Bonus: paired-row format with `rep G` / `rep S` / `rep G&S` codes (parserDIR.ts:43 dedicated branch, otherwise uncovered) and a wide variety of interpretation codes (`LTC`, `ITC`, `HTC-SW`, `HTC-NE`, `HTC-All`, `IT-MAD<`, etc.). |
+| `kola2013_repG_macCR_component_means.dir` | `test-data/potential-data/2000-2014-ARCHIVE/2013-Kola/mag/T/interpret/MiBa/component means.dir` (author: M. Bazhenov, 2013) | **Locks D1 fix** — Mac classic CR-only line endings (no `\n`). The unified regex `/\r\n\|\r\|\n/` (replacing the old `\r?\n` which couldn't match a lone `\r`) is applied across all 9 parsers. Verified by `src/utils/files/__tests__/parserDIR.test.ts` (synthetic CR-only file with standard column layout asserts exact field values; this real archive file asserts the regex split alone, since its non-standard column layout is a separate concern — see Pending follow-ups below). |
 
 More DIR fixtures (`sample.dir`, `field_batch.dir`,
 `v2.6.1/{all_invalid,invalid_rows,malformed}.dir`, plus more paired-format
 files from the Kola T and AF sub-archives) will be added in follow-up PRs
 as the Step 4 parser test suite needs them.
+
+## Pending follow-ups
+
+`kola2013_repG_macCR_component_means.dir` uses a **non-standard column
+layout** for its `rep G` / `rep S` / `rep G&S` rows — wider gaps between
+columns than `parserDIR.ts` expects. After D1 line-ending fix the parser
+no longer collapses the file to one string, but the column slices land
+on the wrong fields (e.g. Dgeo column lands on stepCount). This is a
+**separate** parser-flexibility concern, tracked for a future Phase 1
+follow-up. The fixture stays here to provide both regressions in one
+real-world file: D1 (locked now) and the future column-flexibility fix.
 
 ## Synthetic-fixture matrix
 

--- a/src/utils/files/__tests__/parserDIR.test.ts
+++ b/src/utils/files/__tests__/parserDIR.test.ts
@@ -91,19 +91,18 @@ describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => 
       // tracked as a future Phase 1 column-flexibility fix in the
       // dir/README.md "Pending follow-ups" section.
       //
-      // What D1 proves:
-      //   - the parser visits all 16 non-empty input rows (some get
-      //     pair-consumed by the `rep G` branch), producing a fixed total
-      //     of 11 interpretations + 1 invalidRow = 12 with the current
-      //     parser implementation.
-      //   - the LAST interpretation came from the LAST row of the file
-      //     (label "HTC-Al" — slice(0:7) of " HTC-All "). Without the
-      //     regex fix the parser would have stopped at the merged single
-      //     line and never reached the bottom of the file.
+      // What D1 proves: the parser reaches the LAST row of the file —
+      // label "HTC-Al" comes from slice(0:7) of " HTC-All ". Under the
+      // pre-fix regex the file collapses to a single line and the parser
+      // would only ever see the header row.
+      //
+      // We deliberately do NOT assert an exact total row count: that
+      // number is downstream of the column-layout misparse the future
+      // follow-up will change, and would mis-fire when that fix lands.
       const result = parseDIR(realContent, 'kola2013_repG_macCR_component_means.dir');
       const totalRowsSeen =
         result.data.interpretations.length + result.validation.invalidRows.length;
-      expect(totalRowsSeen).toBe(12);
+      expect(totalRowsSeen).toBeGreaterThan(1);
       const lastLabel = result.data.interpretations[result.data.interpretations.length - 1].label;
       expect(lastLabel).toBe('HTC-Al');
     });

--- a/src/utils/files/__tests__/parserDIR.test.ts
+++ b/src/utils/files/__tests__/parserDIR.test.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import parseDIR from '../parsers/parserDIR';
+
+const fixturesParsers = path.resolve(__dirname, '../../../__tests__/fixtures/parsers');
+
+describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => {
+  // Decomposed into two cases:
+  //
+  //   1. Synthetic CR-only file using the standard parserDIR column layout —
+  //      isolates the D1 fix (line-ending regex) from any column-format
+  //      concern, asserts exact interpretation values.
+  //
+  //   2. The real archive file (kola2013_repG_macCR_component_means.dir) —
+  //      uses a non-standard `rep G&S` column layout that current parserDIR
+  //      cannot interpret correctly (a separate issue, tracked as a future
+  //      Phase 1 column-flexibility fix). For D1 we only assert the file is
+  //      no longer collapsed into a single string by the regex.
+
+  describe('synthetic CR-only file (regex isolation)', () => {
+    // Standard parserDIR column layout:
+    //   [0:7]=label, [7:14]=code, [14:24]=stepRange, [24:27]=N,
+    //   [27:33]=Dgeo, [33:39]=Igeo, [39:45]=Dstrat, [45:51]=Istrat,
+    //   [51:58]=K, [58:64]=MAD, [64:]=comment
+    const row1 = 'test01 GC     T100-T600   7 338.2  36.9 350.0  25.3   2.10 250.0 PCA';
+    const row2 = 'test02 GC     T200-T550   5 145.5 -42.3 157.2 -30.8   3.40 180.0 PCA';
+    const row3 = 'test03 GC     T100-T500   6 340.1  35.2 351.8  23.7   1.80 310.0 PCA';
+    const macCRContent = `${row1}\r${row2}\r${row3}\r`;
+
+    it('splits a Mac-CR-only file into 3 interpretations', () => {
+      // Before the D1 fix, /\r?\n/ could not match a lone \r and the entire
+      // synthetic content collapsed to 1 string → 0 interpretations.
+      const result = parseDIR(macCRContent, 'synthetic-mac-cr.dir');
+      expect(result.data.interpretations).toHaveLength(3);
+      expect(result.data.interpretations.map((interpretation) => interpretation.label)).toEqual([
+        'test01',
+        'test02',
+        'test03',
+      ]);
+    });
+
+    it('preserves Dgeo/Igeo numeric fields through CR-split', () => {
+      const result = parseDIR(macCRContent, 'synthetic-mac-cr.dir');
+      const first = result.data.interpretations[0];
+      expect(first.Dgeo).toBeCloseTo(338.2, 1);
+      expect(first.Igeo).toBeCloseTo(36.9, 1);
+      expect(first.code).toBe('GC');
+      expect(first.gcNormal).toBe(true);
+    });
+
+    it('also handles CRLF and LF line endings (back-compat)', () => {
+      const crlfContent = `${row1}\r\n${row2}\r\n${row3}\r\n`;
+      const lfContent = `${row1}\n${row2}\n${row3}\n`;
+      expect(parseDIR(crlfContent, 'crlf.dir').data.interpretations).toHaveLength(3);
+      expect(parseDIR(lfContent, 'lf.dir').data.interpretations).toHaveLength(3);
+    });
+  });
+
+  describe('real archive file (kola2013_repG_macCR_component_means.dir)', () => {
+    const realContent = fs.readFileSync(
+      path.join(fixturesParsers, 'dir/real/kola2013_repG_macCR_component_means.dir'),
+      'utf-8',
+    );
+
+    it('splits the file into 17 raw lines via the unified regex', () => {
+      // The file has 16 \r terminators (no trailing line). Splitting yields
+      // 17 string fragments. Before the D1 fix this regex match would have
+      // failed and the file would have stayed as 1 monolithic string.
+      const lines = realContent.split(/\r\n|\r|\n/);
+      expect(lines).toHaveLength(17);
+    });
+
+    it('parser walks the lines individually (no single-line collapse)', () => {
+      // The file uses a non-standard `rep G&S` column layout that current
+      // parserDIR cannot interpret correctly (Dgeo column lands in
+      // stepCount, etc.) — this is a SEPARATE issue from D1 and is
+      // tracked as a future Phase 1 column-flexibility fix in the
+      // dir/README.md "Pending follow-ups" section. What D1 proves: the
+      // parser sees more than 1 row of input, so the line-ending fix is
+      // working. Each visited row either becomes an interpretation or an
+      // invalidRow — none are silently lost in a collapsed single line.
+      const result = parseDIR(realContent, 'kola2013_repG_macCR_component_means.dir');
+      const totalRowsSeen =
+        result.data.interpretations.length + result.validation.invalidRows.length;
+      expect(totalRowsSeen).toBeGreaterThan(1);
+    });
+  });
+});

--- a/src/utils/files/__tests__/parserDIR.test.ts
+++ b/src/utils/files/__tests__/parserDIR.test.ts
@@ -18,10 +18,10 @@ describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => 
   //      no longer collapsed into a single string by the regex.
 
   describe('synthetic CR-only file (regex isolation)', () => {
-    // Standard parserDIR column layout:
+    // Standard parserDIR column layout (matches parserDIR.ts slice indices):
     //   [0:7]=label, [7:14]=code, [14:24]=stepRange, [24:27]=N,
     //   [27:33]=Dgeo, [33:39]=Igeo, [39:45]=Dstrat, [45:51]=Istrat,
-    //   [51:58]=K, [58:64]=MAD, [64:]=comment
+    //   [51:58]=MADgeo, [58:64]=Kgeo, [64:]=comment
     const row1 = 'test01 GC     T100-T600   7 338.2  36.9 350.0  25.3   2.10 250.0 PCA';
     const row2 = 'test02 GC     T200-T550   5 145.5 -42.3 157.2 -30.8   3.40 180.0 PCA';
     const row3 = 'test03 GC     T100-T500   6 340.1  35.2 351.8  23.7   1.80 310.0 PCA';
@@ -29,7 +29,11 @@ describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => 
 
     it('splits a Mac-CR-only file into 3 interpretations', () => {
       // Before the D1 fix, /\r?\n/ could not match a lone \r and the entire
-      // synthetic content collapsed to 1 string → 0 interpretations.
+      // synthetic content collapsed to a single string. The parser then
+      // walked that one line and produced a single bogus interpretation
+      // whose first 64 chars happen to match row1's columns; row2 and row3
+      // were swallowed into the trailing comment field. So the test must
+      // assert all three interpretations exist — not just one.
       const result = parseDIR(macCRContent, 'synthetic-mac-cr.dir');
       expect(result.data.interpretations).toHaveLength(3);
       expect(result.data.interpretations.map((interpretation) => interpretation.label)).toEqual([
@@ -39,13 +43,22 @@ describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => 
       ]);
     });
 
-    it('preserves Dgeo/Igeo numeric fields through CR-split', () => {
+    it('preserves Dgeo/Igeo numeric fields on rows that only exist after the CR-split', () => {
+      // Specifically reads interpretations[1] and [2] — these only exist
+      // when the regex actually splits on \r. If we read interpretations[0]
+      // the assertion would pass even with the buggy regex (the merged
+      // single-line content's first 64 chars are exactly row1).
       const result = parseDIR(macCRContent, 'synthetic-mac-cr.dir');
-      const first = result.data.interpretations[0];
-      expect(first.Dgeo).toBeCloseTo(338.2, 1);
-      expect(first.Igeo).toBeCloseTo(36.9, 1);
-      expect(first.code).toBe('GC');
-      expect(first.gcNormal).toBe(true);
+      const second = result.data.interpretations[1];
+      expect(second.label).toBe('test02');
+      expect(second.Dgeo).toBeCloseTo(145.5, 1);
+      expect(second.Igeo).toBeCloseTo(-42.3, 1);
+      expect(second.code).toBe('GC');
+      expect(second.gcNormal).toBe(true);
+      const third = result.data.interpretations[2];
+      expect(third.label).toBe('test03');
+      expect(third.Dgeo).toBeCloseTo(340.1, 1);
+      expect(third.Igeo).toBeCloseTo(35.2, 1);
     });
 
     it('also handles CRLF and LF line endings (back-compat)', () => {
@@ -62,27 +75,37 @@ describe('parserDIR — D1 regression: Mac classic CR-only line endings', () => 
       'utf-8',
     );
 
-    it('splits the file into 17 raw lines via the unified regex', () => {
-      // The file has 16 \r terminators (no trailing line). Splitting yields
-      // 17 string fragments. Before the D1 fix this regex match would have
-      // failed and the file would have stayed as 1 monolithic string.
-      const lines = realContent.split(/\r\n|\r|\n/);
-      expect(lines).toHaveLength(17);
+    it('fixture sanity: file is genuinely CR-only (16 \\r terminators, no \\n)', () => {
+      // Not a parser-fix proof — this just locks the fixture's authenticity.
+      // If someone re-saves the file on a modern editor the line endings
+      // could silently flip to LF, neutralizing the regression value.
+      expect(realContent.split('\r\n')).toHaveLength(1); // no CRLF
+      expect(realContent.split('\n')).toHaveLength(1); // no lone LF
+      expect(realContent.split('\r').length - 1).toBe(16); // 16 CR terminators
     });
 
-    it('parser walks the lines individually (no single-line collapse)', () => {
+    it('parser walks every line of the file (no single-line collapse)', () => {
       // The file uses a non-standard `rep G&S` column layout that current
       // parserDIR cannot interpret correctly (Dgeo column lands in
       // stepCount, etc.) — this is a SEPARATE issue from D1 and is
       // tracked as a future Phase 1 column-flexibility fix in the
-      // dir/README.md "Pending follow-ups" section. What D1 proves: the
-      // parser sees more than 1 row of input, so the line-ending fix is
-      // working. Each visited row either becomes an interpretation or an
-      // invalidRow — none are silently lost in a collapsed single line.
+      // dir/README.md "Pending follow-ups" section.
+      //
+      // What D1 proves:
+      //   - the parser visits all 16 non-empty input rows (some get
+      //     pair-consumed by the `rep G` branch), producing a fixed total
+      //     of 11 interpretations + 1 invalidRow = 12 with the current
+      //     parser implementation.
+      //   - the LAST interpretation came from the LAST row of the file
+      //     (label "HTC-Al" — slice(0:7) of " HTC-All "). Without the
+      //     regex fix the parser would have stopped at the merged single
+      //     line and never reached the bottom of the file.
       const result = parseDIR(realContent, 'kola2013_repG_macCR_component_means.dir');
       const totalRowsSeen =
         result.data.interpretations.length + result.validation.invalidRows.length;
-      expect(totalRowsSeen).toBeGreaterThan(1);
+      expect(totalRowsSeen).toBe(12);
+      const lastLabel = result.data.interpretations[result.data.interpretations.length - 1].label;
+      expect(lastLabel).toBe('HTC-Al');
     });
   });
 });

--- a/src/utils/files/parsers/parserCSV_DIR.ts
+++ b/src/utils/files/parsers/parserCSV_DIR.ts
@@ -7,7 +7,6 @@ import { IDirData } from '../../GlobalTypes';
  * @returns {IDirData} IDirData
  */
 const parseCSV_DIR = (data: string, name: string): IDirData => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);

--- a/src/utils/files/parsers/parserCSV_DIR.ts
+++ b/src/utils/files/parsers/parserCSV_DIR.ts
@@ -8,7 +8,7 @@ import { IDirData } from '../../GlobalTypes';
  */
 const parseCSV_DIR = (data: string, name: string): IDirData => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);
 

--- a/src/utils/files/parsers/parserCSV_PMD.ts
+++ b/src/utils/files/parsers/parserCSV_PMD.ts
@@ -7,7 +7,6 @@ import { IPmdData } from '../../GlobalTypes';
  * @returns {IPmdData} IPmdData
  */
 const parseCSV_PMD = (data: string, name: string): IPmdData => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);

--- a/src/utils/files/parsers/parserCSV_PMD.ts
+++ b/src/utils/files/parsers/parserCSV_PMD.ts
@@ -8,7 +8,7 @@ import { IPmdData } from '../../GlobalTypes';
  */
 const parseCSV_PMD = (data: string, name: string): IPmdData => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);
 

--- a/src/utils/files/parsers/parserCSV_SitesLatLon.ts
+++ b/src/utils/files/parsers/parserCSV_SitesLatLon.ts
@@ -7,7 +7,6 @@ import { ISitesData } from '../../GlobalTypes';
  * @returns {ISitesData} ISitesData
  */
 const parseCSV_SitesLatLon = (data: string, name: string): ISitesData => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);

--- a/src/utils/files/parsers/parserCSV_SitesLatLon.ts
+++ b/src/utils/files/parsers/parserCSV_SitesLatLon.ts
@@ -8,7 +8,7 @@ import { ISitesData } from '../../GlobalTypes';
  */
 const parseCSV_SitesLatLon = (data: string, name: string): ISitesData => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   let lines = data.split(eol).filter((line) => line.length > 1);
 

--- a/src/utils/files/parsers/parserDIR.ts
+++ b/src/utils/files/parsers/parserDIR.ts
@@ -9,7 +9,7 @@ import { InvalidRowInfo, ParseResult } from '../validation';
  */
 const parseDIR = (data: string, name: string): ParseResult<IDirData> => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   const lines = data.split(eol).filter((line) => line.length > 1);
 

--- a/src/utils/files/parsers/parserDIR.ts
+++ b/src/utils/files/parsers/parserDIR.ts
@@ -8,7 +8,6 @@ import { InvalidRowInfo, ParseResult } from '../validation';
  * @returns {ParseResult<IDirData>} Parsed data with validation info
  */
 const parseDIR = (data: string, name: string): ParseResult<IDirData> => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   const lines = data.split(eol).filter((line) => line.length > 1);

--- a/src/utils/files/parsers/parserMDIR.ts
+++ b/src/utils/files/parsers/parserMDIR.ts
@@ -12,7 +12,6 @@ const parseMDIR = (data: string, name: string): IDirData => {
   // .mdir data format combined with .dir data format
   // !!! DEPRECATED
 
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   const lines = data.split(eol).filter((line) => line.length > 1);

--- a/src/utils/files/parsers/parserMDIR.ts
+++ b/src/utils/files/parsers/parserMDIR.ts
@@ -13,7 +13,7 @@ const parseMDIR = (data: string, name: string): IDirData => {
   // !!! DEPRECATED
 
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage)
   const lines = data.split(eol).filter((line) => line.length > 1);
   // it's must an odd number of lines in .mdir file,

--- a/src/utils/files/parsers/parserPMD.ts
+++ b/src/utils/files/parsers/parserPMD.ts
@@ -9,7 +9,7 @@ import { InvalidRowInfo, ParseResult } from '../validation';
  */
 const parsePMD = (data: string, name: string): ParseResult<IPmdData> => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage) and the first one (it's empty)
   const lines = data
     .split(eol)

--- a/src/utils/files/parsers/parserPMD.ts
+++ b/src/utils/files/parsers/parserPMD.ts
@@ -8,7 +8,6 @@ import { InvalidRowInfo, ParseResult } from '../validation';
  * @returns {ParseResult<IPmdData>} Parsed data with validation info
  */
 const parsePMD = (data: string, name: string): ParseResult<IPmdData> => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the last one (it's garbage) and the first one (it's empty)
   const lines = data

--- a/src/utils/files/parsers/parserPMM.ts
+++ b/src/utils/files/parsers/parserPMM.ts
@@ -7,7 +7,6 @@ import { IDirData } from '../../GlobalTypes';
  * @returns {IDirData} IDirData
  */
 const parsePMM = (data: string, name: string): IDirData => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except first and the last one (they're garbage)
   const lines = data

--- a/src/utils/files/parsers/parserPMM.ts
+++ b/src/utils/files/parsers/parserPMM.ts
@@ -8,7 +8,7 @@ import { IDirData } from '../../GlobalTypes';
  */
 const parsePMM = (data: string, name: string): IDirData => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except first and the last one (they're garbage)
   const lines = data
     .split(eol)

--- a/src/utils/files/parsers/parserRS3.ts
+++ b/src/utils/files/parsers/parserRS3.ts
@@ -10,7 +10,7 @@ import toReferenceCoordinates from '../../graphs/formatters/toReferenceCoordinat
  */
 const parserRS3 = (data: string, name: string): IPmdData => {
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
 
   // metadata:
   // Name      Site      Latitude  Longitude  Height    Rock           Age  Fm SDec  SInc  BDec  BInc  FDec  FInc  P1 P2 P3 P4 Note

--- a/src/utils/files/parsers/parserRS3.ts
+++ b/src/utils/files/parsers/parserRS3.ts
@@ -9,7 +9,6 @@ import toReferenceCoordinates from '../../graphs/formatters/toReferenceCoordinat
  * @returns {IPmdData} IPmdData
  */
 const parserRS3 = (data: string, name: string): IPmdData => {
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
 
   // metadata:

--- a/src/utils/files/parsers/parserSQUID.ts
+++ b/src/utils/files/parsers/parserSQUID.ts
@@ -15,7 +15,7 @@ const parseSQUID = (data: string, name: string): IPmdData => {
   }
 
   // eslint-disable-next-line no-control-regex
-  const eol = new RegExp('\r?\n');
+  const eol = /\r\n|\r|\n/;
   // Get all lines except the first one (it's just copy of filename) and all too-short lines
   const lines = data
     .split(eol)

--- a/src/utils/files/parsers/parserSQUID.ts
+++ b/src/utils/files/parsers/parserSQUID.ts
@@ -14,7 +14,6 @@ const parseSQUID = (data: string, name: string): IPmdData => {
     throw new Error(`Empty .squid file: ${name}`);
   }
 
-  // eslint-disable-next-line no-control-regex
   const eol = /\r\n|\r|\n/;
   // Get all lines except the first one (it's just copy of filename) and all too-short lines
   const lines = data


### PR DESCRIPTION
## Summary

Phase 1 Discovery item **D1** — fixed across all 9 parsers in one coordinated commit. Severity at discovery: high (parsers silently produced wrong output on a class of legitimate legacy files).

The old regex `new RegExp('\r?\n')` did **not** match a lone `\r`, so files with Mac classic CR-only line endings collapsed to a single string and parsing returned garbage. The bug was not parserDIR-specific — every parser used the same regex.

## Change

`new RegExp('\r?\n')` → `/\r\n|\r|\n/` in:

| File | Status |
|---|---|
| `parserPMD.ts` | ✅ |
| `parserDIR.ts` | ✅ |
| `parserPMM.ts` | ✅ |
| `parserCSV_PMD.ts` | ✅ |
| `parserCSV_DIR.ts` | ✅ |
| `parserCSV_SitesLatLon.ts` | ✅ |
| `parserMDIR.ts` | ✅ |
| `parserRS3.ts` | ✅ |
| `parserSQUID.ts` | ✅ |

The new regex matches CRLF, CR, and LF independently as line terminators.

## Regression test

`src/utils/files/__tests__/parserDIR.test.ts` decomposes into two cases:

1. **Synthetic CR-only file** with standard parserDIR column layout — asserts exact field values for 3 interpretations (label, code, Dgeo, Igeo, gcNormal). Plus a back-compat assertion that CRLF and LF still produce 3 interpretations.

2. **Real archive file** `kola2013_repG_macCR_component_means.dir` — asserts the file splits into 17 raw lines (16 `\r` terminators) and the parser walks them individually. The archive file's non-standard `rep G&S` column layout is a **separate** parser-flexibility issue, tracked in `parsers/dir/README.md` "Pending follow-ups".

## What's NOT in this PR

- **Synthetic CR-only fixtures for the other 8 parsers** — locked in Phase 1 Step 4 with single-line synthetic generators.
- **DIR column-format flexibility** for the non-standard `rep G&S` layout in `kola2013_repG_macCR_component_means.dir` — separate concern, separate future PR.

## Documentation
- Roadmap D1 section rewritten in past tense (status: fixed, references the test file, flags the pending column-format follow-up).
- `parsers/dir/README.md` updated to "Locks D1 fix" wording + explicit "Pending follow-ups" section.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npm run format:check` clean
- [x] `npm test` 15/15 (4 mergeDir + 6 SQUID + 5 DIR)
- [x] `npm run build` succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)