### PR TITLE
feat(dir): export centered DIR directions (PMM/CSV/XLSX) with CUT45 marking

### DIFF
--- a/src/components/AppLogic/DataTablesDIR/InputDataTable/DataTableDIR.tsx
+++ b/src/components/AppLogic/DataTablesDIR/InputDataTable/DataTableDIR.tsx
@@ -26,16 +26,22 @@ import SettingsBackupRestoreIcon from '@mui/icons-material/SettingsBackupRestore
 
 import { useTheme } from '@mui/material/styles';
 import { primaryColor } from '../../../../utils/ThemeConstants';
-import Direction from '../../../../utils/graphs/classes/Direction';
 import { DIRDataTableColumns, IDataTableDIR } from '../types';
+import reverseDirectionsByIds from '../../../../utils/files/transforms/reverseDirectionsByIds';
+import centerDirectionsByMean from '../../../../utils/files/transforms/centerDirectionsByMean';
+import meanDirectionsOf from '../../../../utils/files/transforms/meanDirectionsOf';
 
 const DataTableDIR: FC<IDataTableDIR> = ({ data }) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
 
-  const { selectedDirectionsIDs, hiddenDirectionsIDs, reversedDirectionsIDs } = useAppSelector(
-    (state) => state.dirPageReducer,
-  );
+  const {
+    selectedDirectionsIDs,
+    hiddenDirectionsIDs,
+    reversedDirectionsIDs,
+    centeredByMean,
+    currentInterpretation,
+  } = useAppSelector((state) => state.dirPageReducer);
 
   // selectionModel is array of ID's of rows
   const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>([]);
@@ -208,9 +214,17 @@ const DataTableDIR: FC<IDataTableDIR> = ({ data }) => {
     col.hideSortIcons = true;
   });
 
+  // Apply the same reversal + center-by-mean the stereonet uses, so the table
+  // matches the graph (and the centered export). Centering needs a Fisher mean.
+  const means = meanDirectionsOf(currentInterpretation);
+  let displayData = data ? reverseDirectionsByIds(data, reversedDirectionsIDs) : null;
+  if (displayData && centeredByMean && means) {
+    displayData = centerDirectionsByMean(displayData, means.geographic, means.stratigraphic);
+  }
+
   let visibleIndex = 1;
-  const rows: Array<DataGridDIRFromDIRRow> = data
-    ? data.interpretations.map((interpretation, index) => {
+  const rows: Array<DataGridDIRFromDIRRow> = displayData
+    ? displayData.interpretations.map((interpretation) => {
         const {
           id,
           label,
@@ -227,16 +241,6 @@ const DataTableDIR: FC<IDataTableDIR> = ({ data }) => {
           Kstrat,
           comment,
         } = interpretation;
-        let geoDirection = new Direction(Dgeo, Igeo, 1);
-        let stratDirection = new Direction(Dstrat, Istrat, 1);
-        if (reversedDirectionsIDs.includes(id)) {
-          geoDirection = geoDirection.reversePolarity();
-          stratDirection = stratDirection.reversePolarity();
-        }
-        const DgeoFinal = +geoDirection.declination.toFixed(1);
-        const IgeoFinal = +geoDirection.inclination.toFixed(1);
-        const DstratFinal = +stratDirection.declination.toFixed(1);
-        const IstratFinal = +stratDirection.inclination.toFixed(1);
         return {
           id,
           index: hiddenDirectionsIDs.includes(id) ? '-' : visibleIndex++,
@@ -244,10 +248,10 @@ const DataTableDIR: FC<IDataTableDIR> = ({ data }) => {
           code: code as StatisticsModeDIR,
           stepRange,
           stepCount,
-          Dgeo: DgeoFinal,
-          Igeo: IgeoFinal,
-          Dstrat: DstratFinal,
-          Istrat: IstratFinal,
+          Dgeo: +Dgeo.toFixed(1),
+          Igeo: +Igeo.toFixed(1),
+          Dstrat: +Dstrat.toFixed(1),
+          Istrat: +Istrat.toFixed(1),
           confidenceRadiusGeo: +MADgeo.toFixed(1),
           accuracyGeo: +(Kgeo || 0).toFixed(1),
           confidenceRadiusStrat: +MADstrat.toFixed(1),

--- a/src/components/AppLogic/DataTablesDIR/InputDataTable/DataTableDIR.tsx
+++ b/src/components/AppLogic/DataTablesDIR/InputDataTable/DataTableDIR.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import styles from './DataTableDIR.module.scss';
 import { DataGridDIRFromDIRRow, IDirData } from '../../../../utils/GlobalTypes';
 import {
@@ -216,11 +216,17 @@ const DataTableDIR: FC<IDataTableDIR> = ({ data }) => {
 
   // Apply the same reversal + center-by-mean the stereonet uses, so the table
   // matches the graph (and the centered export). Centering needs a Fisher mean.
-  const means = meanDirectionsOf(currentInterpretation);
-  let displayData = data ? reverseDirectionsByIds(data, reversedDirectionsIDs) : null;
-  if (displayData && centeredByMean && means) {
-    displayData = centerDirectionsByMean(displayData, means.geographic, means.stratigraphic);
-  }
+  // Memoised so the per-direction rotations don't rerun on every unrelated
+  // render (row selection, hover, theme, …).
+  const means = useMemo(() => meanDirectionsOf(currentInterpretation), [currentInterpretation]);
+  const displayData = useMemo(() => {
+    if (!data) return null;
+    const reversed = reverseDirectionsByIds(data, reversedDirectionsIDs);
+    if (centeredByMean && means) {
+      return centerDirectionsByMean(reversed, means.geographic, means.stratigraphic);
+    }
+    return reversed;
+  }, [data, reversedDirectionsIDs, centeredByMean, means]);
 
   let visibleIndex = 1;
   const rows: Array<DataGridDIRFromDIRRow> = displayData

--- a/src/components/AppLogic/ToolsDIR/CurrentDIRFileSelector.tsx
+++ b/src/components/AppLogic/ToolsDIR/CurrentDIRFileSelector.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../services/store/hooks';
 import { IDirData } from '../../../utils/GlobalTypes';
 import {
@@ -16,6 +16,8 @@ import {
   setHiddenDirectionsIDs,
   deleteAllInterpretations,
   setReversedDirectionsIDs,
+  setCenteredByMean,
+  setCutoffEnabled,
 } from '../../../services/reducers/dirPage';
 import { useTranslation } from 'react-i18next';
 
@@ -27,6 +29,12 @@ const CurrentDIRFileSelector: FC = () => {
 
   const [allDirData, setAllDirData] = useState<Array<IDirData>>([]);
   const [currentFileName, setCurrentFileName] = useState<string>('');
+  // The file this effect last applied its resets for. Guards against re-firing on
+  // an allDirData reference change (e.g. another upload) while the same file is
+  // still selected — which would otherwise wipe the current file's view state.
+  // Keyed on the filename, not the numeric id: deleting another file shifts
+  // indices under a fixed id, and that case must still re-sync to the new file.
+  const lastAppliedFileNameRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (dirStatData) {
@@ -39,12 +47,18 @@ const CurrentDIRFileSelector: FC = () => {
       const filename = allDirData[currentDataDIRid]?.name;
       if (filename) {
         setCurrentFileName(filename);
+        // Only reset per-file state when the selected file actually changes.
+        if (lastAppliedFileNameRef.current === filename) return;
+        lastAppliedFileNameRef.current = filename;
         dispatch(updateCurrentFileInterpretations(filename));
         dispatch(setLastInterpretationAsCurrent());
         dispatch(setSelectedDirectionsIDs(null));
         dispatch(setHiddenDirectionsIDs([]));
         dispatch(setReversedDirectionsIDs([]));
         dispatch(setStatisticsMode(null));
+        // Center-by-mean / cutoff are per-file view state: reset on file switch.
+        dispatch(setCenteredByMean(false));
+        dispatch(setCutoffEnabled(false));
       }
     }
   }, [currentDataDIRid, allDirData]);
@@ -74,6 +88,8 @@ const CurrentDIRFileSelector: FC = () => {
       dispatch(setHiddenDirectionsIDs([]));
       dispatch(setReversedDirectionsIDs([]));
       dispatch(setStatisticsMode(null));
+      dispatch(setCenteredByMean(false));
+      dispatch(setCutoffEnabled(false));
     }
   };
 
@@ -85,6 +101,8 @@ const CurrentDIRFileSelector: FC = () => {
     dispatch(setHiddenDirectionsIDs([]));
     dispatch(setReversedDirectionsIDs([]));
     dispatch(setStatisticsMode(null));
+    dispatch(setCenteredByMean(false));
+    dispatch(setCutoffEnabled(false));
   };
 
   return (

--- a/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/ExportDIRFromDIR.tsx
+++ b/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/ExportDIRFromDIR.tsx
@@ -7,39 +7,39 @@ import DIRExportMenuItem from './MenuItems/DIRExportMenuItem';
 type ExportDIRFromDIRProps = ButtonProps & {
   data: IDirData;
   /**
-   * Directions rotated so the Fisher mean sits at the stereonet centre (with
-   * CUT95 markers when the cutoff is active). When provided, "Export centered"
-   * menu items are shown alongside the regular ones.
+   * Every direction including the ones hidden on the graph, with CUT45 markers
+   * on directions the cutoff rejects. When provided, "Export with hidden" menu
+   * items are shown alongside the regular ones.
    */
-  centeredData?: IDirData | null;
+  withHiddenData?: IDirData | null;
 };
 
 const ExportDIRFromDIR = (props: ExportDIRFromDIRProps) => {
-  const { data, centeredData, ...containerProps } = props;
+  const { data, withHiddenData, ...containerProps } = props;
   return (
     <GridToolbarExportContainer {...containerProps}>
       {/* <DIRExportMenuItem as={'dir'} data={data}/> */}
       <DIRExportMenuItem as={'pmm'} data={data} />
       <DIRExportMenuItem as={'csv'} data={data} />
       <DIRExportMenuItem as={'xlsx'} data={data} />
-      {centeredData && [
+      {withHiddenData && [
         <DIRExportMenuItem
-          key="centered-pmm"
+          key="with-hidden-pmm"
           as={'pmm'}
-          data={centeredData}
-          label="Export centered as PMM"
+          data={withHiddenData}
+          label="Export with hidden as PMM"
         />,
         <DIRExportMenuItem
-          key="centered-csv"
+          key="with-hidden-csv"
           as={'csv'}
-          data={centeredData}
-          label="Export centered as CSV"
+          data={withHiddenData}
+          label="Export with hidden as CSV"
         />,
         <DIRExportMenuItem
-          key="centered-xlsx"
+          key="with-hidden-xlsx"
           as={'xlsx'}
-          data={centeredData}
-          label="Export centered as XLSX"
+          data={withHiddenData}
+          label="Export with hidden as XLSX"
         />,
       ]}
     </GridToolbarExportContainer>

--- a/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/ExportDIRFromDIR.tsx
+++ b/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/ExportDIRFromDIR.tsx
@@ -1,23 +1,47 @@
 import React from 'react';
 import { ButtonProps } from '@mui/material/Button';
-import {
-  GridToolbarExportContainer,
-  GridCsvExportMenuItem,
-  GridCsvExportOptions,
-  GridExportMenuItemProps,
-} from '@mui/x-data-grid';
-import PMDExportMenuItem from './MenuItems/PMDExportMenuItem';
+import { GridToolbarExportContainer } from '@mui/x-data-grid';
 import { IDirData } from '../../../../../../utils/GlobalTypes';
 import DIRExportMenuItem from './MenuItems/DIRExportMenuItem';
 
-const ExportDIRFromDIR = (props: ButtonProps & { data: IDirData }) => {
-  const { data } = props;
+type ExportDIRFromDIRProps = ButtonProps & {
+  data: IDirData;
+  /**
+   * Directions rotated so the Fisher mean sits at the stereonet centre (with
+   * CUT95 markers when the cutoff is active). When provided, "Export centered"
+   * menu items are shown alongside the regular ones.
+   */
+  centeredData?: IDirData | null;
+};
+
+const ExportDIRFromDIR = (props: ExportDIRFromDIRProps) => {
+  const { data, centeredData, ...containerProps } = props;
   return (
-    <GridToolbarExportContainer {...props}>
+    <GridToolbarExportContainer {...containerProps}>
       {/* <DIRExportMenuItem as={'dir'} data={data}/> */}
       <DIRExportMenuItem as={'pmm'} data={data} />
       <DIRExportMenuItem as={'csv'} data={data} />
       <DIRExportMenuItem as={'xlsx'} data={data} />
+      {centeredData && [
+        <DIRExportMenuItem
+          key="centered-pmm"
+          as={'pmm'}
+          data={centeredData}
+          label="Export centered as PMM"
+        />,
+        <DIRExportMenuItem
+          key="centered-csv"
+          as={'csv'}
+          data={centeredData}
+          label="Export centered as CSV"
+        />,
+        <DIRExportMenuItem
+          key="centered-xlsx"
+          as={'xlsx'}
+          data={centeredData}
+          label="Export centered as XLSX"
+        />,
+      ]}
     </GridToolbarExportContainer>
   );
 };

--- a/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/MenuItems/DIRExportMenuItem.tsx
+++ b/src/components/Common/DataTable/Toolbar/Buttons/ExportButton/MenuItems/DIRExportMenuItem.tsx
@@ -7,9 +7,13 @@ import { IDirData } from '../../../../../../../utils/GlobalTypes';
 interface DIRExport {
   as: 'dir' | 'pmm' | 'csv' | 'xlsx';
   data: IDirData;
+  label?: string;
 }
 
-const DIRExportMenuItem: FC<DIRExport> = ({ as, data }, props: GridExportMenuItemProps<{}>) => {
+const DIRExportMenuItem: FC<DIRExport> = (
+  { as, data, label },
+  props: GridExportMenuItemProps<{}>,
+) => {
   const { hideMenu } = props;
 
   const exportAs = {
@@ -50,7 +54,7 @@ const DIRExportMenuItem: FC<DIRExport> = ({ as, data }, props: GridExportMenuIte
         hideMenu?.();
       }}
     >
-      {exportAs[as].label}
+      {label ?? exportAs[as].label}
     </MenuItem>
   );
 };

--- a/src/components/Common/DataTable/Toolbar/DIRInputDataTableToolbar.tsx
+++ b/src/components/Common/DataTable/Toolbar/DIRInputDataTableToolbar.tsx
@@ -5,54 +5,62 @@ import {
   GridToolbarFilterButton,
 } from '@mui/x-data-grid';
 import { useAppSelector } from '../../../../services/store/hooks';
-import { IDirData, IPmdData } from '../../../../utils/GlobalTypes';
-import Direction from '../../../../utils/graphs/classes/Direction';
+import { IDirData } from '../../../../utils/GlobalTypes';
+import reverseDirectionsByIds from '../../../../utils/files/transforms/reverseDirectionsByIds';
+import centerDirectionsByMean from '../../../../utils/files/transforms/centerDirectionsByMean';
+import markCutoffComments from '../../../../utils/files/transforms/markCutoffComments';
+import meanDirectionsOf from '../../../../utils/files/transforms/meanDirectionsOf';
 import ExportDIRFromDIR from './Buttons/ExportButton/ExportDIRFromDIR';
 
 const DIRInputDataTableToolbar = () => {
   const { dirStatData, currentDataDIRid } = useAppSelector((state) => state.parsedDataReducer);
-  const { hiddenDirectionsIDs, reversedDirectionsIDs } = useAppSelector(
-    (state) => state.dirPageReducer,
-  );
+  const {
+    hiddenDirectionsIDs,
+    reversedDirectionsIDs,
+    centeredByMean,
+    cutoffEnabled,
+    cutoffAngle,
+    reference,
+    currentInterpretation,
+  } = useAppSelector((state) => state.dirPageReducer);
 
   if (!dirStatData) return null;
-  const data = { ...dirStatData[currentDataDIRid || 0] };
-  if (data && data.interpretations) {
-    if (hiddenDirectionsIDs.length) {
-      data.interpretations = data.interpretations.filter(
-        (interp) => !hiddenDirectionsIDs.includes(interp.id),
-      );
-    }
-    if (reversedDirectionsIDs.length) {
-      data.interpretations = data.interpretations.map((interp) => {
-        const { id, Dgeo, Igeo, Dstrat, Istrat } = interp;
-        let geoDirection = new Direction(Dgeo, Igeo, 1);
-        let stratDirection = new Direction(Dstrat, Istrat, 1);
-        if (reversedDirectionsIDs.includes(id)) {
-          geoDirection = geoDirection.reversePolarity();
-          stratDirection = stratDirection.reversePolarity();
-        }
-        const DgeoFinal = +geoDirection.declination.toFixed(1);
-        const IgeoFinal = +geoDirection.inclination.toFixed(1);
-        const DstratFinal = +stratDirection.declination.toFixed(1);
-        const IstratFinal = +stratDirection.inclination.toFixed(1);
-        return {
-          ...interp,
-          Dgeo: DgeoFinal,
-          Igeo: IgeoFinal,
-          Dstrat: DstratFinal,
-          Istrat: IstratFinal,
-        };
-      });
-    }
+  const sourceData = dirStatData[currentDataDIRid || 0] as IDirData | undefined;
+  if (!sourceData?.interpretations) return null;
+
+  // Reversal is applied to every export (matches the table and stereonet).
+  const reversedData = reverseDirectionsByIds(sourceData, reversedDirectionsIDs);
+
+  const means = meanDirectionsOf(currentInterpretation);
+  const center = (dirData: IDirData): IDirData =>
+    centeredByMean && means
+      ? centerDirectionsByMean(dirData, means.geographic, means.stratigraphic)
+      : dirData;
+
+  // Regular export: only the directions visible on the graph (hidden dropped).
+  const visibleData = center({
+    ...reversedData,
+    interpretations: reversedData.interpretations.filter(
+      (interpretation) => !hiddenDirectionsIDs.includes(interpretation.id),
+    ),
+  });
+
+  // "Export with hidden": every direction, with CUT45 added to the ones the 45°
+  // cutoff rejects (when the cutoff is on). Cutoff marking is done before
+  // centering because the angular test is rotation-invariant.
+  let withHiddenData: IDirData = reversedData;
+  if (cutoffEnabled && means) {
+    const cutoffMean = reference === 'stratigraphic' ? means.stratigraphic : means.geographic;
+    withHiddenData = markCutoffComments(withHiddenData, cutoffMean, reference, cutoffAngle);
   }
+  withHiddenData = center(withHiddenData);
 
   return (
     <GridToolbarContainer>
       <GridToolbarFilterButton />
       <GridToolbarColumnsButton />
       <GridToolbarDensitySelector />
-      <ExportDIRFromDIR data={data} />
+      <ExportDIRFromDIR data={visibleData} withHiddenData={withHiddenData} />
     </GridToolbarContainer>
   );
 };

--- a/src/components/Common/DataTable/Toolbar/DIRInputDataTableToolbar.tsx
+++ b/src/components/Common/DataTable/Toolbar/DIRInputDataTableToolbar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   GridToolbarContainer,
   GridToolbarColumnsButton,
@@ -24,43 +25,61 @@ const DIRInputDataTableToolbar = () => {
     currentInterpretation,
   } = useAppSelector((state) => state.dirPageReducer);
 
-  if (!dirStatData) return null;
-  const sourceData = dirStatData[currentDataDIRid || 0] as IDirData | undefined;
-  if (!sourceData?.interpretations) return null;
+  // Build the two export datasets once per relevant change instead of on every
+  // render. The null cases are handled inside the memo so it stays above the
+  // early return and respects the Rules of Hooks.
+  const exportData = useMemo(() => {
+    const sourceData = dirStatData?.[currentDataDIRid || 0] as IDirData | undefined;
+    if (!sourceData?.interpretations) return null;
 
-  // Reversal is applied to every export (matches the table and stereonet).
-  const reversedData = reverseDirectionsByIds(sourceData, reversedDirectionsIDs);
+    // Reversal is applied to every export (matches the table and stereonet).
+    const reversedData = reverseDirectionsByIds(sourceData, reversedDirectionsIDs);
 
-  const means = meanDirectionsOf(currentInterpretation);
-  const center = (dirData: IDirData): IDirData =>
-    centeredByMean && means
-      ? centerDirectionsByMean(dirData, means.geographic, means.stratigraphic)
-      : dirData;
+    const means = meanDirectionsOf(currentInterpretation);
+    const center = (dirData: IDirData): IDirData =>
+      centeredByMean && means
+        ? centerDirectionsByMean(dirData, means.geographic, means.stratigraphic)
+        : dirData;
 
-  // Regular export: only the directions visible on the graph (hidden dropped).
-  const visibleData = center({
-    ...reversedData,
-    interpretations: reversedData.interpretations.filter(
-      (interpretation) => !hiddenDirectionsIDs.includes(interpretation.id),
-    ),
-  });
+    // Regular export: only the directions visible on the graph (hidden dropped).
+    const visibleData = center({
+      ...reversedData,
+      interpretations: reversedData.interpretations.filter(
+        (interpretation) => !hiddenDirectionsIDs.includes(interpretation.id),
+      ),
+    });
 
-  // "Export with hidden": every direction, with CUT45 added to the ones the 45°
-  // cutoff rejects (when the cutoff is on). Cutoff marking is done before
-  // centering because the angular test is rotation-invariant.
-  let withHiddenData: IDirData = reversedData;
-  if (cutoffEnabled && means) {
-    const cutoffMean = reference === 'stratigraphic' ? means.stratigraphic : means.geographic;
-    withHiddenData = markCutoffComments(withHiddenData, cutoffMean, reference, cutoffAngle);
-  }
-  withHiddenData = center(withHiddenData);
+    // "Export with hidden": every direction, with CUT45 added to the ones the 45°
+    // cutoff rejects (when the cutoff is on). Cutoff marking is done before
+    // centering because the angular test is rotation-invariant.
+    let withHiddenData: IDirData = reversedData;
+    if (cutoffEnabled && means) {
+      const cutoffMean = reference === 'stratigraphic' ? means.stratigraphic : means.geographic;
+      withHiddenData = markCutoffComments(withHiddenData, cutoffMean, reference, cutoffAngle);
+    }
+    withHiddenData = center(withHiddenData);
+
+    return { visibleData, withHiddenData };
+  }, [
+    dirStatData,
+    currentDataDIRid,
+    hiddenDirectionsIDs,
+    reversedDirectionsIDs,
+    centeredByMean,
+    cutoffEnabled,
+    cutoffAngle,
+    reference,
+    currentInterpretation,
+  ]);
+
+  if (!exportData) return null;
 
   return (
     <GridToolbarContainer>
       <GridToolbarFilterButton />
       <GridToolbarColumnsButton />
       <GridToolbarDensitySelector />
-      <ExportDIRFromDIR data={visibleData} withHiddenData={withHiddenData} />
+      <ExportDIRFromDIR data={exportData.visibleData} withHiddenData={exportData.withHiddenData} />
     </GridToolbarContainer>
   );
 };

--- a/src/components/Common/DataTable/Toolbar/DIRStatisticsDataTableToolbar.tsx
+++ b/src/components/Common/DataTable/Toolbar/DIRStatisticsDataTableToolbar.tsx
@@ -6,12 +6,22 @@ import {
 } from '@mui/x-data-grid';
 import { useAppSelector } from '../../../../services/store/hooks';
 import { IDirData } from '../../../../utils/GlobalTypes';
+import Direction from '../../../../utils/graphs/classes/Direction';
+import centerDirectionsByMean from '../../../../utils/files/transforms/centerDirectionsByMean';
+import markCutoffComments from '../../../../utils/files/transforms/markCutoffComments';
 import ExportDIRFromDIR from './Buttons/ExportButton/ExportDIRFromDIR';
 
 const DIRStatisticsDataTableToolbar = () => {
-  const { currentFileInterpretations, outputFilename } = useAppSelector(
-    (state) => state.dirPageReducer,
-  );
+  const {
+    currentFileInterpretations,
+    currentInterpretation,
+    outputFilename,
+    reference,
+    cutoffEnabled,
+    cutoffAngle,
+    reversedDirectionsIDs,
+    hiddenDirectionsIDs,
+  } = useAppSelector((state) => state.dirPageReducer);
 
   if (!currentFileInterpretations) return null;
   const data: IDirData = {
@@ -39,12 +49,63 @@ const DIRStatisticsDataTableToolbar = () => {
     created: '',
   };
 
+  // "Export centered" payload: exactly the directions visible on the stereonet
+  // (hidden ones dropped, reversed ones flipped), with CUT95 added to cut
+  // directions when the cutoff is active, then rotated so the Fisher mean sits
+  // at the centre. Available only when a mean has been computed.
+  const mean = currentInterpretation?.rawData?.mean;
+  let centeredData: IDirData | null = null;
+  if (mean) {
+    const visibleInterpretations = data.interpretations
+      .filter((interpretation) => !hiddenDirectionsIDs.includes(interpretation.id))
+      .map((interpretation) => {
+        if (!reversedDirectionsIDs.includes(interpretation.id)) return interpretation;
+        const geographic = new Direction(
+          interpretation.Dgeo,
+          interpretation.Igeo,
+          1,
+        ).reversePolarity();
+        const stratigraphic = new Direction(
+          interpretation.Dstrat,
+          interpretation.Istrat,
+          1,
+        ).reversePolarity();
+        return {
+          ...interpretation,
+          Dgeo: +geographic.declination.toFixed(1),
+          Igeo: +geographic.inclination.toFixed(1),
+          Dstrat: +stratigraphic.declination.toFixed(1),
+          Istrat: +stratigraphic.inclination.toFixed(1),
+        };
+      });
+
+    const geographicMean = new Direction(
+      mean.geographic.direction.declination,
+      mean.geographic.direction.inclination,
+      mean.geographic.direction.length,
+    );
+    const stratigraphicMean = new Direction(
+      mean.stratigraphic.direction.declination,
+      mean.stratigraphic.direction.inclination,
+      mean.stratigraphic.direction.length,
+    );
+
+    let payload: IDirData = { ...data, interpretations: visibleInterpretations };
+    // Mark cut directions on the original coordinates first (same predicate as
+    // the stereonet), then centre — the angular cutoff test is rotation-invariant.
+    if (cutoffEnabled) {
+      const cutoffMean = reference === 'stratigraphic' ? stratigraphicMean : geographicMean;
+      payload = markCutoffComments(payload, cutoffMean, reference, cutoffAngle);
+    }
+    centeredData = centerDirectionsByMean(payload, geographicMean, stratigraphicMean);
+  }
+
   return (
     <GridToolbarContainer>
       <GridToolbarFilterButton />
       <GridToolbarColumnsButton />
       <GridToolbarDensitySelector />
-      <ExportDIRFromDIR data={data} />
+      <ExportDIRFromDIR data={data} centeredData={centeredData} />
     </GridToolbarContainer>
   );
 };

--- a/src/components/Common/DataTable/Toolbar/DIRStatisticsDataTableToolbar.tsx
+++ b/src/components/Common/DataTable/Toolbar/DIRStatisticsDataTableToolbar.tsx
@@ -6,22 +6,12 @@ import {
 } from '@mui/x-data-grid';
 import { useAppSelector } from '../../../../services/store/hooks';
 import { IDirData } from '../../../../utils/GlobalTypes';
-import Direction from '../../../../utils/graphs/classes/Direction';
-import centerDirectionsByMean from '../../../../utils/files/transforms/centerDirectionsByMean';
-import markCutoffComments from '../../../../utils/files/transforms/markCutoffComments';
 import ExportDIRFromDIR from './Buttons/ExportButton/ExportDIRFromDIR';
 
 const DIRStatisticsDataTableToolbar = () => {
-  const {
-    currentFileInterpretations,
-    currentInterpretation,
-    outputFilename,
-    reference,
-    cutoffEnabled,
-    cutoffAngle,
-    reversedDirectionsIDs,
-    hiddenDirectionsIDs,
-  } = useAppSelector((state) => state.dirPageReducer);
+  const { currentFileInterpretations, outputFilename } = useAppSelector(
+    (state) => state.dirPageReducer,
+  );
 
   if (!currentFileInterpretations) return null;
   const data: IDirData = {
@@ -49,63 +39,12 @@ const DIRStatisticsDataTableToolbar = () => {
     created: '',
   };
 
-  // "Export centered" payload: exactly the directions visible on the stereonet
-  // (hidden ones dropped, reversed ones flipped), with CUT95 added to cut
-  // directions when the cutoff is active, then rotated so the Fisher mean sits
-  // at the centre. Available only when a mean has been computed.
-  const mean = currentInterpretation?.rawData?.mean;
-  let centeredData: IDirData | null = null;
-  if (mean) {
-    const visibleInterpretations = data.interpretations
-      .filter((interpretation) => !hiddenDirectionsIDs.includes(interpretation.id))
-      .map((interpretation) => {
-        if (!reversedDirectionsIDs.includes(interpretation.id)) return interpretation;
-        const geographic = new Direction(
-          interpretation.Dgeo,
-          interpretation.Igeo,
-          1,
-        ).reversePolarity();
-        const stratigraphic = new Direction(
-          interpretation.Dstrat,
-          interpretation.Istrat,
-          1,
-        ).reversePolarity();
-        return {
-          ...interpretation,
-          Dgeo: +geographic.declination.toFixed(1),
-          Igeo: +geographic.inclination.toFixed(1),
-          Dstrat: +stratigraphic.declination.toFixed(1),
-          Istrat: +stratigraphic.inclination.toFixed(1),
-        };
-      });
-
-    const geographicMean = new Direction(
-      mean.geographic.direction.declination,
-      mean.geographic.direction.inclination,
-      mean.geographic.direction.length,
-    );
-    const stratigraphicMean = new Direction(
-      mean.stratigraphic.direction.declination,
-      mean.stratigraphic.direction.inclination,
-      mean.stratigraphic.direction.length,
-    );
-
-    let payload: IDirData = { ...data, interpretations: visibleInterpretations };
-    // Mark cut directions on the original coordinates first (same predicate as
-    // the stereonet), then centre — the angular cutoff test is rotation-invariant.
-    if (cutoffEnabled) {
-      const cutoffMean = reference === 'stratigraphic' ? stratigraphicMean : geographicMean;
-      payload = markCutoffComments(payload, cutoffMean, reference, cutoffAngle);
-    }
-    centeredData = centerDirectionsByMean(payload, geographicMean, stratigraphicMean);
-  }
-
   return (
     <GridToolbarContainer>
       <GridToolbarFilterButton />
       <GridToolbarColumnsButton />
       <GridToolbarDensitySelector />
-      <ExportDIRFromDIR data={data} centeredData={centeredData} />
+      <ExportDIRFromDIR data={data} />
     </GridToolbarContainer>
   );
 };

--- a/src/pages/DIRPage/Graphs.tsx
+++ b/src/pages/DIRPage/Graphs.tsx
@@ -5,7 +5,11 @@ import { IDirData } from '../../utils/GlobalTypes';
 import GraphsSkeleton from './GraphsSkeleton';
 import { StereoGraphDIR } from '../../components/AppGraphs';
 import { useAppDispatch, useAppSelector } from '../../services/store/hooks';
-import { addHiddenDirectionsIDs, removeHiddenDirectionsIDs } from '../../services/reducers/dirPage';
+import {
+  addHiddenDirectionsIDs,
+  removeHiddenDirectionsIDs,
+  setCutoffEnabled,
+} from '../../services/reducers/dirPage';
 import Direction from '../../utils/graphs/classes/Direction';
 import { strangeRotation } from '../../utils/statistics/matrix';
 
@@ -20,12 +24,18 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
   const graphRef = useRef<HTMLDivElement>(null);
   const graphToExportRef = useRef<HTMLDivElement>(null);
   const { menuItems, settings } = useDIRGraphSettings();
-  const { reference, currentInterpretation } = useAppSelector((state) => state.dirPageReducer);
+  const { reference, currentInterpretation, cutoffEnabled, cutoffAngle } = useAppSelector(
+    (state) => state.dirPageReducer,
+  );
+
+  // Cutoff enable/angle live in Redux so the export menu can read them; the
+  // remaining cutoff visibility toggles stay local to the graph.
+  const enableCutoff = cutoffEnabled;
+  const setEnableCutoff: React.Dispatch<React.SetStateAction<boolean>> = (value) =>
+    dispatch(setCutoffEnabled(typeof value === 'function' ? value(cutoffEnabled) : value));
 
   const [graphSize, setGraphSize] = useState<number>(300);
   const [centeredByMean, setCenteredByMean] = useState<boolean>(false);
-  const [enableCutoff, setEnableCutoff] = useState<boolean>(false);
-  const [cutoffAngle, setCutoffAngle] = useState<number>(45); // degrees
   const [showCutoffCircle, setShowCutoffCircle] = useState<boolean>(true);
   const [showCutoffOuterDots, setShowCutoffOuterDots] = useState<boolean>(false);
 

--- a/src/pages/DIRPage/Graphs.tsx
+++ b/src/pages/DIRPage/Graphs.tsx
@@ -33,6 +33,7 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
     cutoffEnabled,
     cutoffAngle,
     reversedDirectionsIDs,
+    hiddenDirectionsIDs,
   } = useAppSelector((state) => state.dirPageReducer);
 
   // Center-by-mean and cutoff enable/angle live in Redux so the directions table
@@ -86,13 +87,44 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
     return newDirsToHideIDs;
   }, [currentInterpretation, dataToShow, reversedDirectionsIDs, reference, cutoffAngle]);
 
+  // Remember which ids the cutoff currently hides, so when the outlier set
+  // changes (Geo↔Strat flip, a reversal, or a recomputed mean) we can re-sync:
+  // drop the ids that are no longer cut and hide the newly-cut ones — without
+  // disturbing directions the user hid manually. `cutoffOuterDotsIDs` must be in
+  // the dependency array or this never re-runs on those changes.
+  const appliedCutoffIDsRef = useRef<number[]>([]);
+  // Latest hidden set, read inside the effect without making it a dependency
+  // (that would re-run the effect on its own dispatch and risk a loop).
+  const hiddenDirectionsIDsRef = useRef(hiddenDirectionsIDs);
+  hiddenDirectionsIDsRef.current = hiddenDirectionsIDs;
+
   useEffect(() => {
-    if (dataToShow && enableCutoff && !showCutoffOuterDots) {
-      dispatch(addHiddenDirectionsIDs(cutoffOuterDotsIDs));
-    } else if ((dataToShow && !enableCutoff) || (dataToShow && showCutoffOuterDots)) {
-      dispatch(removeHiddenDirectionsIDs(cutoffOuterDotsIDs));
-    }
-  }, [enableCutoff, showCutoffOuterDots, dataToShow]);
+    if (!dataToShow) return;
+    const shouldHide = enableCutoff && !showCutoffOuterDots;
+    const nextCutoffIDs = shouldHide ? cutoffOuterDotsIDs : [];
+    const currentlyHidden = hiddenDirectionsIDsRef.current;
+    // Release only ids the cutoff itself hid and that are no longer cut.
+    const idsToRelease = appliedCutoffIDsRef.current.filter((id) => !nextCutoffIDs.includes(id));
+    // Hide newly-cut ids that aren't already hidden (manually or by a prior pass).
+    const idsToHide = nextCutoffIDs.filter((id) => !currentlyHidden.includes(id));
+    if (idsToRelease.length) dispatch(removeHiddenDirectionsIDs(idsToRelease));
+    if (idsToHide.length) dispatch(addHiddenDirectionsIDs(idsToHide));
+    // The cutoff "owns" only ids it actually hid: still-cut ids it owned before,
+    // plus the ones it just hid. Ids already hidden by hand are never owned, so
+    // disabling the cutoff can never reveal a manual hide.
+    //
+    // Known limitation: hidden state is a single set with no per-id provenance,
+    // and the eye icon (setHiddenDirectionsIDs, a full replace) does not re-run
+    // this effect. So if the user manually un-hides then re-hides a direction
+    // that the cutoff is also hiding, the cutoff still "owns" it and disabling
+    // the cutoff releases it. Fully fixing this needs separate cutoff-hidden vs
+    // manually-hidden sets; this is still strictly better than the prior code,
+    // which cleared the entire hidden set whenever the cutoff was switched off.
+    appliedCutoffIDsRef.current = [
+      ...appliedCutoffIDsRef.current.filter((id) => nextCutoffIDs.includes(id)),
+      ...idsToHide,
+    ];
+  }, [enableCutoff, showCutoffOuterDots, dataToShow, cutoffOuterDotsIDs, dispatch]);
 
   if (!dataToShow)
     return (

--- a/src/pages/DIRPage/Graphs.tsx
+++ b/src/pages/DIRPage/Graphs.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../services/reducers/dirPage';
 import Direction from '../../utils/graphs/classes/Direction';
 import { strangeRotation } from '../../utils/statistics/matrix';
+import reverseDirectionsByIds from '../../utils/files/transforms/reverseDirectionsByIds';
 
 interface IGraphs {
   dataToShow: IDirData | null;
@@ -25,8 +26,14 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
   const graphRef = useRef<HTMLDivElement>(null);
   const graphToExportRef = useRef<HTMLDivElement>(null);
   const { menuItems, settings } = useDIRGraphSettings();
-  const { reference, currentInterpretation, centeredByMean, cutoffEnabled, cutoffAngle } =
-    useAppSelector((state) => state.dirPageReducer);
+  const {
+    reference,
+    currentInterpretation,
+    centeredByMean,
+    cutoffEnabled,
+    cutoffAngle,
+    reversedDirectionsIDs,
+  } = useAppSelector((state) => state.dirPageReducer);
 
   // Center-by-mean and cutoff enable/angle live in Redux so the directions table
   // and export menu can read them; the remaining cutoff visibility toggles stay
@@ -60,8 +67,14 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
       meanDirection.inclination,
       meanDirection.length,
     );
-    // затем берём все имеющиеся векторы и фильтруем их по их удалённости от среднего направления
-    const newDirsToHideIDs = dataToShow.interpretations
+    // Test the cutoff against the SAME reversed/aligned coordinates the stereonet
+    // plots and the Fisher mean was computed in. Without this, a reversed direction
+    // sitting on the mean would be measured at its raw antipodal position (~180°
+    // away) and wrongly hidden — so the 45° circle drawn on screen would not match
+    // which dots it actually cuts. Mirrors the export path (reverseDirectionsByIds
+    // then markCutoffComments). When nothing is reversed this is a no-op copy.
+    const alignedData = reverseDirectionsByIds(dataToShow, reversedDirectionsIDs);
+    const newDirsToHideIDs = alignedData.interpretations
       .filter((direction) => {
         const { Dgeo, Igeo, Dstrat, Istrat } = direction;
         const inReferenceCoords: [number, number] =
@@ -71,7 +84,7 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
       })
       .map((dir) => dir.id);
     return newDirsToHideIDs;
-  }, [currentInterpretation, dataToShow]);
+  }, [currentInterpretation, dataToShow, reversedDirectionsIDs, reference, cutoffAngle]);
 
   useEffect(() => {
     if (dataToShow && enableCutoff && !showCutoffOuterDots) {

--- a/src/pages/DIRPage/Graphs.tsx
+++ b/src/pages/DIRPage/Graphs.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from '../../services/store/hooks';
 import {
   addHiddenDirectionsIDs,
   removeHiddenDirectionsIDs,
+  setCenteredByMean as setCenteredByMeanAction,
   setCutoffEnabled,
 } from '../../services/reducers/dirPage';
 import Direction from '../../utils/graphs/classes/Direction';
@@ -24,18 +25,19 @@ const Graphs: FC<IGraphs> = ({ dataToShow }) => {
   const graphRef = useRef<HTMLDivElement>(null);
   const graphToExportRef = useRef<HTMLDivElement>(null);
   const { menuItems, settings } = useDIRGraphSettings();
-  const { reference, currentInterpretation, cutoffEnabled, cutoffAngle } = useAppSelector(
-    (state) => state.dirPageReducer,
-  );
+  const { reference, currentInterpretation, centeredByMean, cutoffEnabled, cutoffAngle } =
+    useAppSelector((state) => state.dirPageReducer);
 
-  // Cutoff enable/angle live in Redux so the export menu can read them; the
-  // remaining cutoff visibility toggles stay local to the graph.
+  // Center-by-mean and cutoff enable/angle live in Redux so the directions table
+  // and export menu can read them; the remaining cutoff visibility toggles stay
+  // local to the graph.
+  const setCenteredByMean: React.Dispatch<React.SetStateAction<boolean>> = (value) =>
+    dispatch(setCenteredByMeanAction(typeof value === 'function' ? value(centeredByMean) : value));
   const enableCutoff = cutoffEnabled;
   const setEnableCutoff: React.Dispatch<React.SetStateAction<boolean>> = (value) =>
     dispatch(setCutoffEnabled(typeof value === 'function' ? value(cutoffEnabled) : value));
 
   const [graphSize, setGraphSize] = useState<number>(300);
-  const [centeredByMean, setCenteredByMean] = useState<boolean>(false);
   const [showCutoffCircle, setShowCutoffCircle] = useState<boolean>(true);
   const [showCutoffOuterDots, setShowCutoffOuterDots] = useState<boolean>(false);
 

--- a/src/pages/DIRPage/__tests__/Graphs.cutoffResync.test.tsx
+++ b/src/pages/DIRPage/__tests__/Graphs.cutoffResync.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import Graphs from '../Graphs';
+import { setupStore, AppStore } from '../../../services/store/store';
+import {
+  addInterpretation,
+  setReference,
+  setCutoffEnabled,
+  setHiddenDirectionsIDs,
+} from '../../../services/reducers/dirPage';
+import { IDirData } from '../../../utils/GlobalTypes';
+
+// The real stereonet is a heavy SVG component irrelevant to the cutoff-hiding
+// effect under test — stub it. Same for the graph-settings/window-size hooks.
+// (babel-jest hoists these jest.mock calls above the imports above.)
+jest.mock('../../../components/AppGraphs', () => ({
+  StereoGraphDIR: () => null,
+}));
+jest.mock('../../../utils/GlobalHooks', () => ({
+  useDIRGraphSettings: () => ({ menuItems: [], settings: {} }),
+  useWindowSize: () => [1000, 800],
+}));
+
+type Interpretation = IDirData['interpretations'][number];
+
+const makeInterpretation = (overrides: Partial<Interpretation>): Interpretation => ({
+  id: 1,
+  label: 'S',
+  code: '',
+  stepRange: '0-100',
+  stepCount: 5,
+  Dgeo: 0,
+  Igeo: 0,
+  Dstrat: 0,
+  Istrat: 0,
+  MADgeo: 2,
+  Kgeo: 50,
+  MADstrat: 2,
+  Kstrat: 50,
+  comment: '',
+  demagType: 'thermal',
+  ...overrides,
+});
+
+// Mean at the stereonet centre (0, 90): a direction sits (90 - inclination)°
+// from it. So with a 45° cutoff, inclination < 45° is an outlier.
+//  - direction 1: kept in geographic (Igeo 80 → 10°), cut in stratigraphic (Istrat 10 → 80°)
+//  - direction 2: cut in geographic (Igeo 10 → 80°), kept in stratigraphic (Istrat 80 → 10°)
+const data: IDirData = {
+  name: 'file.dir',
+  format: 'DIR',
+  created: '',
+  interpretations: [
+    makeInterpretation({ id: 1, Dgeo: 0, Igeo: 80, Dstrat: 0, Istrat: 10 }),
+    makeInterpretation({ id: 2, Dgeo: 0, Igeo: 10, Dstrat: 0, Istrat: 80 }),
+  ],
+};
+
+const centreMean = { declination: 0, inclination: 90, length: 1 };
+const interpretation = {
+  uuid: 'u1',
+  parentFile: 'file.dir',
+  label: 'mean',
+  code: 'fisher',
+  rawData: {
+    code: 'fisher',
+    mean: {
+      geographic: { direction: centreMean, MAD: 3 },
+      stratigraphic: { direction: centreMean, MAD: 3 },
+    },
+  },
+} as never;
+
+const renderGraphs = (store: AppStore) =>
+  render(
+    <Provider store={store}>
+      <Graphs dataToShow={data} />
+    </Provider>,
+  );
+
+const hidden = (store: AppStore) => [...store.getState().dirPageReducer.hiddenDirectionsIDs].sort();
+
+describe('DIR cutoff hiding re-syncs when the outlier set changes', () => {
+  it('flipping Geo↔Strat with the cutoff on hides the new reference outliers, not the stale ones', () => {
+    const store = setupStore();
+    store.dispatch(addInterpretation({ interpretation }));
+    store.dispatch(setReference('geographic'));
+    store.dispatch(setCutoffEnabled(true));
+
+    renderGraphs(store);
+    // geographic: direction 2 is the outlier
+    expect(hidden(store)).toEqual([2]);
+
+    act(() => {
+      store.dispatch(setReference('stratigraphic'));
+    });
+    // stratigraphic: direction 1 is the outlier; the stale id 2 must be released
+    expect(hidden(store)).toEqual([1]);
+  });
+
+  it('disabling the cutoff preserves directions hidden manually', () => {
+    const store = setupStore();
+    store.dispatch(addInterpretation({ interpretation }));
+    store.dispatch(setReference('geographic'));
+    // user manually hides direction 1 (which the cutoff would keep)
+    store.dispatch(setHiddenDirectionsIDs([1]));
+
+    renderGraphs(store);
+
+    act(() => {
+      store.dispatch(setCutoffEnabled(true));
+    });
+    // manual hide (1) + cutoff outlier (2)
+    expect(hidden(store)).toEqual([1, 2]);
+
+    act(() => {
+      store.dispatch(setCutoffEnabled(false));
+    });
+    // cutoff outlier released, manual hide kept
+    expect(hidden(store)).toEqual([1]);
+  });
+
+  it('keeps a manual hide that is ALSO a cutoff outlier when the cutoff is turned off', () => {
+    const store = setupStore();
+    store.dispatch(addInterpretation({ interpretation }));
+    store.dispatch(setReference('stratigraphic'));
+    // id 1 is the stratigraphic outlier; the user also hides it by hand, so the
+    // manual hide and the cutoff overlap on the same id.
+    store.dispatch(setHiddenDirectionsIDs([1]));
+
+    renderGraphs(store);
+
+    act(() => {
+      store.dispatch(setCutoffEnabled(true));
+    });
+    // already hidden manually; the cutoff adds nothing new
+    expect(hidden(store)).toEqual([1]);
+
+    act(() => {
+      store.dispatch(setCutoffEnabled(false));
+    });
+    // the manual hide survives — the cutoff never "owned" id 1
+    expect(hidden(store)).toEqual([1]);
+  });
+});

--- a/src/services/reducers/__tests__/dirPage.test.ts
+++ b/src/services/reducers/__tests__/dirPage.test.ts
@@ -1,0 +1,54 @@
+import dirPageReducer, {
+  setHiddenDirectionsIDs,
+  addHiddenDirectionsIDs,
+  removeHiddenDirectionsIDs,
+  setCenteredByMean,
+  setCutoffEnabled,
+  setCutoffAngle,
+} from '../dirPage';
+
+const initialState = dirPageReducer(undefined, { type: '@@INIT' });
+
+describe('dirPage reducer — hidden directions', () => {
+  it('removeHiddenDirectionsIDs removes only the ids in the payload, keeping the rest', () => {
+    const withHidden = dirPageReducer(initialState, setHiddenDirectionsIDs([1, 2, 3, 4]));
+    const next = dirPageReducer(withHidden, removeHiddenDirectionsIDs([2, 4]));
+    expect(next.hiddenDirectionsIDs).toEqual([1, 3]);
+  });
+
+  it('removeHiddenDirectionsIDs leaves manually-hidden ids that are not in the payload', () => {
+    // This is the cutoff re-sync invariant: dropping cutoff outliers must not
+    // wipe directions the user hid by hand.
+    const manuallyHidden = dirPageReducer(initialState, setHiddenDirectionsIDs([10, 20]));
+    const next = dirPageReducer(manuallyHidden, removeHiddenDirectionsIDs([99]));
+    expect(next.hiddenDirectionsIDs).toEqual([10, 20]);
+  });
+
+  it('addHiddenDirectionsIDs unions without introducing duplicates', () => {
+    const first = dirPageReducer(initialState, addHiddenDirectionsIDs([1, 2]));
+    const second = dirPageReducer(first, addHiddenDirectionsIDs([2, 3]));
+    expect([...second.hiddenDirectionsIDs].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('dirPage reducer — center-by-mean / cutoff view state', () => {
+  it('setCenteredByMean toggles the flag', () => {
+    expect(dirPageReducer(initialState, setCenteredByMean(true)).centeredByMean).toBe(true);
+    const on = dirPageReducer(initialState, setCenteredByMean(true));
+    expect(dirPageReducer(on, setCenteredByMean(false)).centeredByMean).toBe(false);
+  });
+
+  it('setCutoffEnabled toggles the flag', () => {
+    expect(dirPageReducer(initialState, setCutoffEnabled(true)).cutoffEnabled).toBe(true);
+  });
+
+  it('setCutoffAngle updates the angle', () => {
+    expect(dirPageReducer(initialState, setCutoffAngle(30)).cutoffAngle).toBe(30);
+  });
+
+  it('defaults: centeredByMean false, cutoffEnabled false, cutoffAngle 45', () => {
+    expect(initialState.centeredByMean).toBe(false);
+    expect(initialState.cutoffEnabled).toBe(false);
+    expect(initialState.cutoffAngle).toBe(45);
+  });
+});

--- a/src/services/reducers/dirPage.ts
+++ b/src/services/reducers/dirPage.ts
@@ -19,6 +19,8 @@ interface IInitialState {
   showSelectionInput: boolean;
   showVGPMean: boolean;
   labelModeIsNumeric: boolean;
+  cutoffEnabled: boolean;
+  cutoffAngle: number;
 }
 
 const initialState: IInitialState = {
@@ -37,6 +39,8 @@ const initialState: IInitialState = {
   showSelectionInput: false,
   showVGPMean: false,
   labelModeIsNumeric: false,
+  cutoffEnabled: false,
+  cutoffAngle: 45,
 };
 
 const dirPage = createSlice({
@@ -79,6 +83,13 @@ const dirPage = createSlice({
     },
     setStatisticsMode(state, action) {
       state.statisticsMode = action.payload;
+    },
+    // Cutoff view-state (shared between the DIR stereonet and the export menu)
+    setCutoffEnabled(state, action: { payload: boolean }) {
+      state.cutoffEnabled = action.payload;
+    },
+    setCutoffAngle(state, action: { payload: number }) {
+      state.cutoffAngle = action.payload;
     },
     toggleCommentsInput(state) {
       state.isCommentsInputVisible = !state.isCommentsInputVisible;
@@ -248,6 +259,8 @@ export const {
   setReversedDirectionsIDs,
   addReversedDirectionsIDs,
   setStatisticsMode,
+  setCutoffEnabled,
+  setCutoffAngle,
   toggleCommentsInput,
   setCommentsInput,
   showSelectionInput,

--- a/src/services/reducers/dirPage.ts
+++ b/src/services/reducers/dirPage.ts
@@ -19,6 +19,7 @@ interface IInitialState {
   showSelectionInput: boolean;
   showVGPMean: boolean;
   labelModeIsNumeric: boolean;
+  centeredByMean: boolean;
   cutoffEnabled: boolean;
   cutoffAngle: number;
 }
@@ -39,6 +40,7 @@ const initialState: IInitialState = {
   showSelectionInput: false,
   showVGPMean: false,
   labelModeIsNumeric: false,
+  centeredByMean: false,
   cutoffEnabled: false,
   cutoffAngle: 45,
 };
@@ -84,7 +86,11 @@ const dirPage = createSlice({
     setStatisticsMode(state, action) {
       state.statisticsMode = action.payload;
     },
-    // Cutoff view-state (shared between the DIR stereonet and the export menu)
+    // Center-by-mean / cutoff view-state (shared between the DIR stereonet,
+    // the directions table and the export menu)
+    setCenteredByMean(state, action: { payload: boolean }) {
+      state.centeredByMean = action.payload;
+    },
     setCutoffEnabled(state, action: { payload: boolean }) {
       state.cutoffEnabled = action.payload;
     },
@@ -259,6 +265,7 @@ export const {
   setReversedDirectionsIDs,
   addReversedDirectionsIDs,
   setStatisticsMode,
+  setCenteredByMean,
   setCutoffEnabled,
   setCutoffAngle,
   toggleCommentsInput,

--- a/src/services/reducers/dirPage.ts
+++ b/src/services/reducers/dirPage.ts
@@ -66,10 +66,12 @@ const dirPage = createSlice({
       state.hiddenDirectionsIDs = updatedHiddenDirectionsIDs;
     },
     removeHiddenDirectionsIDs(state, action: { payload: Array<number> }) {
-      const visibleDirectionsIDs = [...new Set([...state.hiddenDirectionsIDs, ...action.payload])];
-      state.hiddenDirectionsIDs = state.hiddenDirectionsIDs.filter(
-        (id) => !visibleDirectionsIDs.includes(id),
-      );
+      // Remove only the ids in the payload — directions hidden by other means
+      // (e.g. the eye icon) must stay hidden. (Previously this unioned the
+      // payload with the current set and filtered all of them out, so it always
+      // cleared every hidden direction regardless of the payload.)
+      const idsToRemove = new Set(action.payload);
+      state.hiddenDirectionsIDs = state.hiddenDirectionsIDs.filter((id) => !idsToRemove.has(id));
     },
     setReversedDirectionsIDs(state, action: { payload: Array<number> }) {
       state.reversedDirectionsIDs = action.payload;

--- a/src/utils/files/__tests__/centerDirectionsByMean.test.ts
+++ b/src/utils/files/__tests__/centerDirectionsByMean.test.ts
@@ -1,0 +1,139 @@
+import centerDirectionsByMean from '../transforms/centerDirectionsByMean';
+import Direction from '../../graphs/classes/Direction';
+import { IDirData } from '../../GlobalTypes';
+
+type Interpretation = IDirData['interpretations'][number];
+
+const makeInterpretation = (overrides: Partial<Interpretation>): Interpretation => ({
+  id: 1,
+  label: 'S1',
+  code: '',
+  stepRange: '0-100',
+  stepCount: 5,
+  Dgeo: 0,
+  Igeo: 0,
+  Dstrat: 0,
+  Istrat: 0,
+  MADgeo: 2,
+  Kgeo: 50,
+  MADstrat: 2,
+  Kstrat: 50,
+  comment: '',
+  demagType: 'thermal',
+  ...overrides,
+});
+
+const makeData = (interpretations: Interpretation[]): IDirData => ({
+  name: 'test',
+  interpretations,
+  format: 'DIR',
+  created: '',
+});
+
+describe('centerDirectionsByMean', () => {
+  it('moves a direction equal to the mean to the centre (inclination 90)', () => {
+    const geographicMean = new Direction(120, 40, 1);
+    const stratigraphicMean = new Direction(300, 10, 1);
+    const data = makeData([makeInterpretation({ Dgeo: 120, Igeo: 40, Dstrat: 300, Istrat: 10 })]);
+
+    const [centered] = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+
+    expect(centered.Igeo).toBeCloseTo(90, 1);
+    expect(centered.Istrat).toBeCloseTo(90, 1);
+  });
+
+  it('preserves the angle between two directions (rotation is rigid)', () => {
+    const geographicMean = new Direction(120, 40, 1);
+    const stratigraphicMean = new Direction(120, 40, 1);
+    const firstDirection = { Dgeo: 100, Igeo: 30 };
+    const secondDirection = { Dgeo: 200, Igeo: 60 };
+    const data = makeData([
+      makeInterpretation({ id: 1, ...firstDirection, Dstrat: 100, Istrat: 30 }),
+      makeInterpretation({ id: 2, ...secondDirection, Dstrat: 200, Istrat: 60 }),
+    ]);
+
+    const originalAngle = new Direction(firstDirection.Dgeo, firstDirection.Igeo, 1).angle(
+      new Direction(secondDirection.Dgeo, secondDirection.Igeo, 1),
+    );
+
+    const [first, second] = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+    const centeredAngle = new Direction(first.Dgeo, first.Igeo, 1).angle(
+      new Direction(second.Dgeo, second.Igeo, 1),
+    );
+
+    // tolerance 0.5° absorbs the 0.1° rounding applied to each coordinate
+    expect(centeredAngle).toBeCloseTo(originalAngle, 0);
+  });
+
+  it('rotates geographic and stratigraphic coordinates about their own means', () => {
+    const geographicMean = new Direction(120, 40, 1);
+    const stratigraphicMean = new Direction(40, 70, 1);
+    const data = makeData([makeInterpretation({ Dgeo: 120, Igeo: 40, Dstrat: 40, Istrat: 70 })]);
+
+    const [centered] = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+
+    // each coordinate set, equal to its own mean, lands at the centre
+    expect(centered.Igeo).toBeCloseTo(90, 1);
+    expect(centered.Istrat).toBeCloseTo(90, 1);
+  });
+
+  it('preserves every field other than D/I and returns a new object', () => {
+    const geographicMean = new Direction(10, 20, 1);
+    const stratigraphicMean = new Direction(10, 20, 1);
+    const original = makeInterpretation({
+      id: 7,
+      label: 'sample-7',
+      code: 'fisher',
+      comment: 'keep me',
+      MADgeo: 3.4,
+      Kgeo: 88,
+      Dgeo: 55,
+      Igeo: 12,
+      Dstrat: 55,
+      Istrat: 12,
+    });
+    const data = makeData([original]);
+
+    const result = centerDirectionsByMean(data, geographicMean, stratigraphicMean);
+    const [centered] = result.interpretations;
+
+    expect(centered.label).toBe('sample-7');
+    expect(centered.code).toBe('fisher');
+    expect(centered.comment).toBe('keep me');
+    expect(centered.MADgeo).toBe(3.4);
+    expect(centered.Kgeo).toBe(88);
+    // original input is untouched (pure function)
+    expect(data.interpretations[0].Dgeo).toBe(55);
+    expect(result).not.toBe(data);
+  });
+
+  it('rounds recomputed declination/inclination to one decimal place', () => {
+    const geographicMean = new Direction(73, 41, 1);
+    const stratigraphicMean = new Direction(73, 41, 1);
+    const data = makeData([makeInterpretation({ Dgeo: 188, Igeo: 17, Dstrat: 188, Istrat: 17 })]);
+
+    const [centered] = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+
+    const hasAtMostOneDecimal = (value: number) => Number(value.toFixed(1)) === value;
+    expect(hasAtMostOneDecimal(centered.Dgeo)).toBe(true);
+    expect(hasAtMostOneDecimal(centered.Igeo)).toBe(true);
+    expect(hasAtMostOneDecimal(centered.Dstrat)).toBe(true);
+    expect(hasAtMostOneDecimal(centered.Istrat)).toBe(true);
+  });
+});

--- a/src/utils/files/__tests__/markCutoffComments.test.ts
+++ b/src/utils/files/__tests__/markCutoffComments.test.ts
@@ -55,7 +55,7 @@ describe('markCutoffComments', () => {
     expect(rejected.comment).toBe(`outlier; ${CUTOFF_COMMENT_MARKER}`);
   });
 
-  it('is idempotent — does not add a duplicate CUT95 marker', () => {
+  it('is idempotent — does not add a duplicate CUT45 marker', () => {
     const data = makeData([makeInterpretation({ Dgeo: 0, Igeo: 40 })]);
 
     const once = markCutoffComments(data, centreMean, 'geographic', 45);

--- a/src/utils/files/__tests__/markCutoffComments.test.ts
+++ b/src/utils/files/__tests__/markCutoffComments.test.ts
@@ -1,0 +1,88 @@
+import markCutoffComments, { CUTOFF_COMMENT_MARKER } from '../transforms/markCutoffComments';
+import Direction from '../../graphs/classes/Direction';
+import { IDirData } from '../../GlobalTypes';
+
+type Interpretation = IDirData['interpretations'][number];
+
+const makeInterpretation = (overrides: Partial<Interpretation>): Interpretation => ({
+  id: 1,
+  label: 'S1',
+  code: '',
+  stepRange: '0-100',
+  stepCount: 5,
+  Dgeo: 0,
+  Igeo: 0,
+  Dstrat: 0,
+  Istrat: 0,
+  MADgeo: 2,
+  Kgeo: 50,
+  MADstrat: 2,
+  Kstrat: 50,
+  comment: '',
+  demagType: 'thermal',
+  ...overrides,
+});
+
+const makeData = (interpretations: Interpretation[]): IDirData => ({
+  name: 'test',
+  interpretations,
+  format: 'DIR',
+  created: '',
+});
+
+// Mean at the centre of the stereonet: a direction at inclination I sits
+// (90 - I)° away from it. So Igeo 80 → 10° (kept), Igeo 40 → 50° (rejected).
+const centreMean = new Direction(0, 90, 1);
+
+describe('markCutoffComments', () => {
+  it('marks only directions beyond the cutoff angle from the mean', () => {
+    const data = makeData([
+      makeInterpretation({ id: 1, Dgeo: 0, Igeo: 80 }), // 10° from mean — kept
+      makeInterpretation({ id: 2, Dgeo: 0, Igeo: 40 }), // 50° from mean — rejected
+    ]);
+
+    const [kept, rejected] = markCutoffComments(data, centreMean, 'geographic', 45).interpretations;
+
+    expect(kept.comment).toBe('');
+    expect(rejected.comment).toBe(CUTOFF_COMMENT_MARKER);
+  });
+
+  it('appends to an existing comment without overwriting it', () => {
+    const data = makeData([makeInterpretation({ Dgeo: 0, Igeo: 40, comment: 'outlier' })]);
+
+    const [rejected] = markCutoffComments(data, centreMean, 'geographic', 45).interpretations;
+
+    expect(rejected.comment).toBe(`outlier; ${CUTOFF_COMMENT_MARKER}`);
+  });
+
+  it('is idempotent — does not add a duplicate CUT95 marker', () => {
+    const data = makeData([makeInterpretation({ Dgeo: 0, Igeo: 40 })]);
+
+    const once = markCutoffComments(data, centreMean, 'geographic', 45);
+    const twice = markCutoffComments(once, centreMean, 'geographic', 45);
+
+    expect(twice.interpretations[0].comment).toBe(CUTOFF_COMMENT_MARKER);
+  });
+
+  it('tests stratigraphic coordinates when reference is stratigraphic', () => {
+    const data = makeData([
+      // geographic coords are inside the cutoff, stratigraphic coords are outside
+      makeInterpretation({ id: 1, Dgeo: 0, Igeo: 85, Dstrat: 0, Istrat: 30 }),
+    ]);
+
+    const geographicResult = markCutoffComments(data, centreMean, 'geographic', 45);
+    const stratigraphicResult = markCutoffComments(data, centreMean, 'stratigraphic', 45);
+
+    expect(geographicResult.interpretations[0].comment).toBe('');
+    expect(stratigraphicResult.interpretations[0].comment).toBe(CUTOFF_COMMENT_MARKER);
+  });
+
+  it('does not mutate the input dataset', () => {
+    const data = makeData([makeInterpretation({ Dgeo: 0, Igeo: 40 })]);
+
+    const result = markCutoffComments(data, centreMean, 'geographic', 45);
+
+    expect(data.interpretations[0].comment).toBe('');
+    expect(result).not.toBe(data);
+  });
+});

--- a/src/utils/files/__tests__/meanDirectionsOf.test.ts
+++ b/src/utils/files/__tests__/meanDirectionsOf.test.ts
@@ -1,0 +1,62 @@
+import meanDirectionsOf from '../transforms/meanDirectionsOf';
+import Direction from '../../graphs/classes/Direction';
+import { StatisitcsInterpretationFromDIR } from '../../GlobalTypes';
+
+// Redux serializes the stored mean, stripping the Direction methods — the mean
+// arrives as a plain { declination, inclination, length } object. We simulate
+// that here (a plain object cast to Direction) so the test reflects the real
+// shape meanDirectionsOf has to rebuild from.
+const plainDirection = (declination: number, inclination: number, length = 1): Direction =>
+  ({ declination, inclination, length }) as unknown as Direction;
+
+const makeInterpretation = (
+  geographic: Direction,
+  stratigraphic: Direction,
+): StatisitcsInterpretationFromDIR =>
+  ({
+    rawData: {
+      code: 'fisher',
+      mean: {
+        geographic: { direction: geographic, MAD: 3 },
+        stratigraphic: { direction: stratigraphic, MAD: 3 },
+      },
+    },
+  }) as unknown as StatisitcsInterpretationFromDIR;
+
+describe('meanDirectionsOf', () => {
+  it('returns null when the interpretation is null', () => {
+    expect(meanDirectionsOf(null)).toBeNull();
+  });
+
+  it('returns null when the interpretation carries no mean', () => {
+    const interpretation = { rawData: undefined } as unknown as StatisitcsInterpretationFromDIR;
+    expect(meanDirectionsOf(interpretation)).toBeNull();
+  });
+
+  it('reconstructs both geographic and stratigraphic means with the stored D/I/length', () => {
+    const interpretation = makeInterpretation(
+      plainDirection(120, 40, 1),
+      plainDirection(300, 10, 1),
+    );
+
+    const means = meanDirectionsOf(interpretation);
+
+    expect(means).not.toBeNull();
+    expect(means?.geographic.declination).toBe(120);
+    expect(means?.geographic.inclination).toBe(40);
+    expect(means?.stratigraphic.declination).toBe(300);
+    expect(means?.stratigraphic.inclination).toBe(10);
+  });
+
+  it('rebuilds real Direction instances whose methods work (the reason it exists)', () => {
+    // input means are plain objects (no methods), as they come back from Redux
+    const interpretation = makeInterpretation(plainDirection(0, 90), plainDirection(0, 90));
+
+    const means = meanDirectionsOf(interpretation);
+
+    expect(means?.geographic).toBeInstanceOf(Direction);
+    expect(means?.stratigraphic).toBeInstanceOf(Direction);
+    // a direction at the centre is 10° from one at inclination 80 — method is callable
+    expect(means?.geographic.angle(new Direction(0, 80, 1))).toBeCloseTo(10, 1);
+  });
+});

--- a/src/utils/files/__tests__/reverseDirectionsByIds.test.ts
+++ b/src/utils/files/__tests__/reverseDirectionsByIds.test.ts
@@ -1,0 +1,71 @@
+import reverseDirectionsByIds from '../transforms/reverseDirectionsByIds';
+import { IDirData } from '../../GlobalTypes';
+
+type Interpretation = IDirData['interpretations'][number];
+
+const makeInterpretation = (overrides: Partial<Interpretation>): Interpretation => ({
+  id: 1,
+  label: 'S1',
+  code: '',
+  stepRange: '0-100',
+  stepCount: 5,
+  Dgeo: 0,
+  Igeo: 0,
+  Dstrat: 0,
+  Istrat: 0,
+  MADgeo: 2,
+  Kgeo: 50,
+  MADstrat: 2,
+  Kstrat: 50,
+  comment: '',
+  demagType: 'thermal',
+  ...overrides,
+});
+
+const makeData = (interpretations: Interpretation[]): IDirData => ({
+  name: 'test',
+  interpretations,
+  format: 'DIR',
+  created: '',
+});
+
+describe('reverseDirectionsByIds', () => {
+  it('flips polarity (D+180, I negated) for listed ids in both coordinate sets', () => {
+    const data = makeData([
+      makeInterpretation({ id: 1, Dgeo: 30, Igeo: 40, Dstrat: 50, Istrat: 60 }),
+    ]);
+
+    const [reversed] = reverseDirectionsByIds(data, [1]).interpretations;
+
+    expect(reversed.Dgeo).toBe(210);
+    expect(reversed.Igeo).toBe(-40);
+    expect(reversed.Dstrat).toBe(230);
+    expect(reversed.Istrat).toBe(-60);
+  });
+
+  it('leaves directions not in the list untouched', () => {
+    const data = makeData([
+      makeInterpretation({ id: 1, Dgeo: 30, Igeo: 40 }),
+      makeInterpretation({ id: 2, Dgeo: 100, Igeo: 10 }),
+    ]);
+
+    const [first, second] = reverseDirectionsByIds(data, [2]).interpretations;
+
+    expect(first.Dgeo).toBe(30);
+    expect(first.Igeo).toBe(40);
+    expect(second.Dgeo).toBe(280);
+    expect(second.Igeo).toBe(-10);
+  });
+
+  it('returns the same dataset reference when no ids are given', () => {
+    const data = makeData([makeInterpretation({ id: 1 })]);
+    expect(reverseDirectionsByIds(data, [])).toBe(data);
+  });
+
+  it('does not mutate the input', () => {
+    const data = makeData([makeInterpretation({ id: 1, Dgeo: 30, Igeo: 40 })]);
+    reverseDirectionsByIds(data, [1]);
+    expect(data.interpretations[0].Dgeo).toBe(30);
+    expect(data.interpretations[0].Igeo).toBe(40);
+  });
+});

--- a/src/utils/files/transforms/centerDirectionsByMean.ts
+++ b/src/utils/files/transforms/centerDirectionsByMean.ts
@@ -1,0 +1,63 @@
+import { IDirData } from '../../GlobalTypes';
+import Direction from '../../graphs/classes/Direction';
+import { strangeRotation } from '../../statistics/matrix';
+
+/**
+ * Rotates a single direction so that the given mean direction is moved to the
+ * centre of the stereonet (declination 0, inclination 90). This is the exact
+ * two-step rotation sequence used by dataToStereoDIR for the on-screen
+ * "Center by mean" view, so exported data matches what the user sees.
+ * @param {number} declination - direction declination, degrees
+ * @param {number} inclination - direction inclination, degrees
+ * @param {Direction} mean - the mean direction to centre on
+ * @returns {[number, number]} rotated [declination, inclination], rounded to 0.1°
+ */
+const centerDirectionAboutMean = (
+  declination: number,
+  inclination: number,
+  mean: Direction,
+): [number, number] => {
+  const directionVector = new Direction(declination, inclination, 1);
+  const firstRotationDirection = new Direction(mean.declination, 0, 1);
+  const secondRotationDirection = new Direction(0, mean.inclination - 90, 1);
+  const firstRotation = strangeRotation(directionVector, firstRotationDirection);
+  const secondRotation = strangeRotation(firstRotation, secondRotationDirection);
+  const [rotatedDeclination, rotatedInclination] = secondRotation.toArray();
+  return [+rotatedDeclination.toFixed(1), +rotatedInclination.toFixed(1)];
+};
+
+/**
+ * Returns a copy of the parsed DIR dataset with every direction rotated so the
+ * Fisher mean sits at the centre of the stereonet — the data equivalent of the
+ * "Center by mean" graph toggle. Geographic coordinates (Dgeo/Igeo) are rotated
+ * about the geographic mean and stratigraphic coordinates (Dstrat/Istrat) about
+ * the stratigraphic mean. Every other field is preserved untouched; only the
+ * declination/inclination pairs change.
+ * @param {IDirData} data - parsed directional data
+ * @param {Direction} geographicMean - mean direction in geographic coordinates
+ * @param {Direction} stratigraphicMean - mean direction in stratigraphic coordinates
+ * @returns {IDirData} a new dataset with recomputed D/I
+ */
+const centerDirectionsByMean = (
+  data: IDirData,
+  geographicMean: Direction,
+  stratigraphicMean: Direction,
+): IDirData => {
+  const centeredInterpretations = data.interpretations.map((interpretation) => {
+    const [Dgeo, Igeo] = centerDirectionAboutMean(
+      interpretation.Dgeo,
+      interpretation.Igeo,
+      geographicMean,
+    );
+    const [Dstrat, Istrat] = centerDirectionAboutMean(
+      interpretation.Dstrat,
+      interpretation.Istrat,
+      stratigraphicMean,
+    );
+    return { ...interpretation, Dgeo, Igeo, Dstrat, Istrat };
+  });
+
+  return { ...data, interpretations: centeredInterpretations };
+};
+
+export default centerDirectionsByMean;

--- a/src/utils/files/transforms/centerDirectionsByMean.ts
+++ b/src/utils/files/transforms/centerDirectionsByMean.ts
@@ -1,12 +1,13 @@
 import { IDirData } from '../../GlobalTypes';
 import Direction from '../../graphs/classes/Direction';
-import { strangeRotation } from '../../statistics/matrix';
+import centerDirectionOnMean from '../../graphs/centerDirectionOnMean';
 
 /**
  * Rotates a single direction so that the given mean direction is moved to the
- * centre of the stereonet (declination 0, inclination 90). This is the exact
- * two-step rotation sequence used by dataToStereoDIR for the on-screen
- * "Center by mean" view, so exported data matches what the user sees.
+ * centre of the stereonet (declination 0, inclination 90), rounding the result
+ * to 0.1°. Delegates to the shared centerDirectionOnMean helper — the same
+ * rotation dataToStereoDIR uses for the on-screen "Center by mean" view — so
+ * exported data matches what the user sees.
  * @param {number} declination - direction declination, degrees
  * @param {number} inclination - direction inclination, degrees
  * @param {Direction} mean - the mean direction to centre on
@@ -17,12 +18,11 @@ const centerDirectionAboutMean = (
   inclination: number,
   mean: Direction,
 ): [number, number] => {
-  const directionVector = new Direction(declination, inclination, 1);
-  const firstRotationDirection = new Direction(mean.declination, 0, 1);
-  const secondRotationDirection = new Direction(0, mean.inclination - 90, 1);
-  const firstRotation = strangeRotation(directionVector, firstRotationDirection);
-  const secondRotation = strangeRotation(firstRotation, secondRotationDirection);
-  const [rotatedDeclination, rotatedInclination] = secondRotation.toArray();
+  const [rotatedDeclination, rotatedInclination] = centerDirectionOnMean(
+    declination,
+    inclination,
+    mean,
+  );
   return [+rotatedDeclination.toFixed(1), +rotatedInclination.toFixed(1)];
 };
 

--- a/src/utils/files/transforms/markCutoffComments.ts
+++ b/src/utils/files/transforms/markCutoffComments.ts
@@ -3,11 +3,11 @@ import Direction from '../../graphs/classes/Direction';
 import { Reference } from '../../graphs/types';
 
 /** Marker appended to the comment of directions rejected by the cutoff. */
-export const CUTOFF_COMMENT_MARKER = 'CUT95';
+export const CUTOFF_COMMENT_MARKER = 'CUT45';
 
 /**
  * Returns a copy of the parsed DIR dataset where every direction whose angular
- * distance from the mean exceeds the cutoff angle has the "CUT95" marker
+ * distance from the mean exceeds the cutoff angle has the "CUT45" marker
  * appended to its comment. The angular test mirrors the 45° cutoff drawn on the
  * DIR stereonet (DIRPage/Graphs.tsx). Directions are kept in place — none are
  * removed — so the export records which directions the cutoff rejected.
@@ -15,7 +15,7 @@ export const CUTOFF_COMMENT_MARKER = 'CUT95';
  * @param {Direction} mean - mean direction the cutoff is measured from
  * @param {Reference} reference - which coordinates to test ('stratigraphic' uses Dstrat/Istrat, otherwise Dgeo/Igeo)
  * @param {number} cutoffAngle - cutoff angle in degrees (45 in the common case)
- * @returns {IDirData} a new dataset with CUT95 added to rejected directions' comments
+ * @returns {IDirData} a new dataset with CUT45 added to rejected directions' comments
  */
 const markCutoffComments = (
   data: IDirData,

--- a/src/utils/files/transforms/markCutoffComments.ts
+++ b/src/utils/files/transforms/markCutoffComments.ts
@@ -1,0 +1,47 @@
+import { IDirData } from '../../GlobalTypes';
+import Direction from '../../graphs/classes/Direction';
+import { Reference } from '../../graphs/types';
+
+/** Marker appended to the comment of directions rejected by the cutoff. */
+export const CUTOFF_COMMENT_MARKER = 'CUT95';
+
+/**
+ * Returns a copy of the parsed DIR dataset where every direction whose angular
+ * distance from the mean exceeds the cutoff angle has the "CUT95" marker
+ * appended to its comment. The angular test mirrors the 45° cutoff drawn on the
+ * DIR stereonet (DIRPage/Graphs.tsx). Directions are kept in place — none are
+ * removed — so the export records which directions the cutoff rejected.
+ * @param {IDirData} data - parsed directional data
+ * @param {Direction} mean - mean direction the cutoff is measured from
+ * @param {Reference} reference - which coordinates to test ('stratigraphic' uses Dstrat/Istrat, otherwise Dgeo/Igeo)
+ * @param {number} cutoffAngle - cutoff angle in degrees (45 in the common case)
+ * @returns {IDirData} a new dataset with CUT95 added to rejected directions' comments
+ */
+const markCutoffComments = (
+  data: IDirData,
+  mean: Direction,
+  reference: Reference,
+  cutoffAngle: number,
+): IDirData => {
+  const markedInterpretations = data.interpretations.map((interpretation) => {
+    const [declination, inclination] =
+      reference === 'stratigraphic'
+        ? [interpretation.Dstrat, interpretation.Istrat]
+        : [interpretation.Dgeo, interpretation.Igeo];
+    const directionVector = new Direction(declination, inclination, 1);
+    const isRejectedByCutoff = mean.angle(directionVector) > cutoffAngle;
+
+    if (!isRejectedByCutoff || interpretation.comment.includes(CUTOFF_COMMENT_MARKER)) {
+      return interpretation;
+    }
+
+    const comment = interpretation.comment
+      ? `${interpretation.comment}; ${CUTOFF_COMMENT_MARKER}`
+      : CUTOFF_COMMENT_MARKER;
+    return { ...interpretation, comment };
+  });
+
+  return { ...data, interpretations: markedInterpretations };
+};
+
+export default markCutoffComments;

--- a/src/utils/files/transforms/meanDirectionsOf.ts
+++ b/src/utils/files/transforms/meanDirectionsOf.ts
@@ -1,0 +1,31 @@
+import { StatisitcsInterpretationFromDIR } from '../../GlobalTypes';
+import Direction from '../../graphs/classes/Direction';
+
+/**
+ * Reconstructs the geographic and stratigraphic Fisher mean directions from a
+ * DIR statistics interpretation as Direction instances. Redux stores them as
+ * plain objects (methods stripped on serialization), so callers that need the
+ * Direction methods (rotation, angle) must rebuild them — this centralises that.
+ * @param {StatisitcsInterpretationFromDIR | null} interpretation - current interpretation
+ * @returns {{ geographic: Direction; stratigraphic: Direction } | null} means, or null when no mean exists
+ */
+const meanDirectionsOf = (
+  interpretation: StatisitcsInterpretationFromDIR | null,
+): { geographic: Direction; stratigraphic: Direction } | null => {
+  const mean = interpretation?.rawData?.mean;
+  if (!mean) return null;
+  return {
+    geographic: new Direction(
+      mean.geographic.direction.declination,
+      mean.geographic.direction.inclination,
+      mean.geographic.direction.length,
+    ),
+    stratigraphic: new Direction(
+      mean.stratigraphic.direction.declination,
+      mean.stratigraphic.direction.inclination,
+      mean.stratigraphic.direction.length,
+    ),
+  };
+};
+
+export default meanDirectionsOf;

--- a/src/utils/files/transforms/reverseDirectionsByIds.ts
+++ b/src/utils/files/transforms/reverseDirectionsByIds.ts
@@ -1,0 +1,36 @@
+import { IDirData } from '../../GlobalTypes';
+import Direction from '../../graphs/classes/Direction';
+
+/**
+ * Returns a copy of the parsed DIR dataset with the polarity of the listed
+ * directions reversed (both geographic and stratigraphic coordinates), matching
+ * what the DIR table and stereonet show for reversed directions. Directions not
+ * in the list are left untouched. D/I are rounded to 0.1° as elsewhere.
+ * @param {IDirData} data - parsed directional data
+ * @param {number[]} reversedDirectionsIDs - ids of directions to flip
+ * @returns {IDirData} a new dataset with the listed directions reversed
+ */
+const reverseDirectionsByIds = (data: IDirData, reversedDirectionsIDs: number[]): IDirData => {
+  if (!reversedDirectionsIDs.length) return data;
+
+  const interpretations = data.interpretations.map((interpretation) => {
+    if (!reversedDirectionsIDs.includes(interpretation.id)) return interpretation;
+    const geographic = new Direction(interpretation.Dgeo, interpretation.Igeo, 1).reversePolarity();
+    const stratigraphic = new Direction(
+      interpretation.Dstrat,
+      interpretation.Istrat,
+      1,
+    ).reversePolarity();
+    return {
+      ...interpretation,
+      Dgeo: +geographic.declination.toFixed(1),
+      Igeo: +geographic.inclination.toFixed(1),
+      Dstrat: +stratigraphic.declination.toFixed(1),
+      Istrat: +stratigraphic.inclination.toFixed(1),
+    };
+  });
+
+  return { ...data, interpretations };
+};
+
+export default reverseDirectionsByIds;

--- a/src/utils/graphs/__tests__/centerDirectionOnMean.test.ts
+++ b/src/utils/graphs/__tests__/centerDirectionOnMean.test.ts
@@ -1,0 +1,76 @@
+import centerDirectionOnMean from '../centerDirectionOnMean';
+import Direction from '../classes/Direction';
+
+describe('centerDirectionOnMean', () => {
+  it('moves a direction equal to the mean to the centre (inclination 90)', () => {
+    const mean = new Direction(120, 40, 1);
+    const [, inclination] = centerDirectionOnMean(120, 40, mean);
+    expect(inclination).toBeCloseTo(90, 5);
+  });
+
+  it('is a rigid rotation — preserves the angle between two directions', () => {
+    const mean = new Direction(120, 40, 1);
+    const first = { declination: 100, inclination: 30 };
+    const second = { declination: 200, inclination: 60 };
+
+    const originalAngle = new Direction(first.declination, first.inclination, 1).angle(
+      new Direction(second.declination, second.inclination, 1),
+    );
+
+    const [firstDeclination, firstInclination] = centerDirectionOnMean(
+      first.declination,
+      first.inclination,
+      mean,
+    );
+    const [secondDeclination, secondInclination] = centerDirectionOnMean(
+      second.declination,
+      second.inclination,
+      mean,
+    );
+    const centeredAngle = new Direction(firstDeclination, firstInclination, 1).angle(
+      new Direction(secondDeclination, secondInclination, 1),
+    );
+
+    expect(centeredAngle).toBeCloseTo(originalAngle, 4);
+  });
+
+  it('returns the raw (unrounded) rotation — callers round for display', () => {
+    // The export transform rounds to 0.1°; the shared helper must NOT, so the
+    // stereonet keeps full plotting precision. This input lands off a 0.1° grid.
+    const mean = new Direction(73, 41, 1);
+    const [declination, inclination] = centerDirectionOnMean(188, 17, mean);
+    const offGrid = (value: number) => Number(value.toFixed(1)) !== value;
+    expect(offGrid(declination) || offGrid(inclination)).toBe(true);
+  });
+
+  // Independent oracle (does NOT compare against the helper itself): centering
+  // moves the mean to the stereonet centre (0, 90), so every direction's angular
+  // distance from the centre AFTER centering must equal its distance from the
+  // mean BEFORE. This is a geometric necessity of any correct centering rotation,
+  // so it catches axis-order / sign / offset regressions in the math itself —
+  // e.g. an injected `[d + 7, i + 3]` fails this. It is the math backstop for the
+  // agreement-only tests in dataToStereoDIR.test.ts.
+  it('preserves each direction’s angular distance from the mean as distance from the centre', () => {
+    const mean = new Direction(47, 23, 1);
+    const centre = new Direction(0, 90, 1);
+    const samples: Array<[number, number]> = [
+      [10, 5],
+      [120, 40],
+      [250, -30],
+      [300, 70],
+      [47, 23], // equal to the mean → must land at the centre (distance 0)
+    ];
+    samples.forEach(([declination, inclination]) => {
+      const distanceFromMean = mean.angle(new Direction(declination, inclination, 1));
+      const [centeredDeclination, centeredInclination] = centerDirectionOnMean(
+        declination,
+        inclination,
+        mean,
+      );
+      const distanceFromCentre = centre.angle(
+        new Direction(centeredDeclination, centeredInclination, 1),
+      );
+      expect(distanceFromCentre).toBeCloseTo(distanceFromMean, 4);
+    });
+  });
+});

--- a/src/utils/graphs/centerDirectionOnMean.ts
+++ b/src/utils/graphs/centerDirectionOnMean.ts
@@ -1,0 +1,34 @@
+import Direction from './classes/Direction';
+import { strangeRotation } from '../statistics/matrix';
+
+/**
+ * Rotates a single direction so that the given mean direction is moved to the
+ * centre of the stereonet (declination 0, inclination 90). This is the exact
+ * two-step rotation sequence behind the DIR "Center by mean" view.
+ *
+ * Shared by the on-screen stereonet formatter (dataToStereoDIR) and the
+ * centered-export/table transform (centerDirectionsByMean) so the exported and
+ * tabulated data always match the plotted dots — one rotation, one
+ * implementation, no risk of the two drifting apart.
+ *
+ * The result is left UNROUNDED; callers round for display where they need to
+ * (the stereonet keeps full precision for plotting, the export rounds to 0.1°).
+ * @param {number} declination - direction declination, degrees
+ * @param {number} inclination - direction inclination, degrees
+ * @param {Direction} mean - the mean direction to centre on
+ * @returns {[number, number]} rotated [declination, inclination], unrounded
+ */
+const centerDirectionOnMean = (
+  declination: number,
+  inclination: number,
+  mean: Direction,
+): [number, number] => {
+  const directionVector = new Direction(declination, inclination, 1);
+  const firstRotationDirection = new Direction(mean.declination, 0, 1);
+  const secondRotationDirection = new Direction(0, mean.inclination - 90, 1);
+  const firstRotation = strangeRotation(directionVector, firstRotationDirection);
+  const secondRotation = strangeRotation(firstRotation, secondRotationDirection);
+  return secondRotation.toArray();
+};
+
+export default centerDirectionOnMean;

--- a/src/utils/graphs/formatters/stereo/__tests__/dataToStereoDIR.test.ts
+++ b/src/utils/graphs/formatters/stereo/__tests__/dataToStereoDIR.test.ts
@@ -1,0 +1,169 @@
+import dataToStereoDIR from '../dataToStereoDIR';
+import reverseDirectionsByIds from '../../../../files/transforms/reverseDirectionsByIds';
+import centerDirectionsByMean from '../../../../files/transforms/centerDirectionsByMean';
+import Direction from '../../../classes/Direction';
+import { IDirData, RawStatisticsDIR } from '../../../../GlobalTypes';
+
+type Interpretation = IDirData['interpretations'][number];
+
+const makeInterpretation = (overrides: Partial<Interpretation>): Interpretation => ({
+  id: 1,
+  label: 'S1',
+  code: '',
+  stepRange: '0-100',
+  stepCount: 5,
+  Dgeo: 0,
+  Igeo: 0,
+  Dstrat: 0,
+  Istrat: 0,
+  MADgeo: 2,
+  Kgeo: 50,
+  MADstrat: 2,
+  Kstrat: 50,
+  comment: '',
+  demagType: 'thermal',
+  ...overrides,
+});
+
+const makeData = (interpretations: Interpretation[]): IDirData => ({
+  name: 'test',
+  interpretations,
+  format: 'DIR',
+  created: '',
+});
+
+const geographicMean = new Direction(30, 50, 1);
+const stratigraphicMean = new Direction(200, 20, 1);
+const statistics: RawStatisticsDIR = {
+  code: 'fisher',
+  mean: {
+    geographic: { direction: geographicMean, MAD: 5 },
+    stratigraphic: { direction: stratigraphicMean, MAD: 5 },
+  },
+};
+
+const data = makeData([
+  makeInterpretation({ id: 1, Dgeo: 12, Igeo: 34, Dstrat: 18, Istrat: 28 }),
+  makeInterpretation({ id: 2, Dgeo: 222, Igeo: -10, Dstrat: 210, Istrat: -5 }),
+  makeInterpretation({ id: 3, Dgeo: 95, Igeo: 60, Dstrat: 88, Istrat: 51 }),
+]);
+
+const graphSize = 250;
+const noneHidden: number[] = [];
+
+// These lock the invariant the feature exists for: the dots the stereonet plots
+// and the data the table/export produce come from the same transforms (now via
+// the shared centerDirectionOnMean + reverseDirectionsByIds), so they cannot
+// drift apart.
+describe('dataToStereoDIR — plotted coords match the export transforms', () => {
+  it('reversal only: plotted geographic coords equal reverseDirectionsByIds', () => {
+    const reversedIDs = [2];
+    const { directionalData } = dataToStereoDIR(
+      data,
+      graphSize,
+      'geographic',
+      noneHidden,
+      reversedIDs,
+      false,
+      statistics,
+      false,
+    );
+    const expected = reverseDirectionsByIds(data, reversedIDs).interpretations;
+    directionalData.forEach(([declination, inclination], index) => {
+      expect(+declination.toFixed(1)).toBe(expected[index].Dgeo);
+      expect(+inclination.toFixed(1)).toBe(expected[index].Igeo);
+    });
+  });
+
+  it('center-by-mean: plotted geographic coords equal centerDirectionsByMean', () => {
+    const { directionalData } = dataToStereoDIR(
+      data,
+      graphSize,
+      'geographic',
+      noneHidden,
+      [],
+      true,
+      statistics,
+      false,
+    );
+    const expected = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+    directionalData.forEach(([declination, inclination], index) => {
+      expect(+declination.toFixed(1)).toBe(expected[index].Dgeo);
+      expect(+inclination.toFixed(1)).toBe(expected[index].Igeo);
+    });
+  });
+
+  it('reversal + center-by-mean together match reverse-then-center', () => {
+    const reversedIDs = [2];
+    const { directionalData } = dataToStereoDIR(
+      data,
+      graphSize,
+      'geographic',
+      noneHidden,
+      reversedIDs,
+      true,
+      statistics,
+      false,
+    );
+    const expected = centerDirectionsByMean(
+      reverseDirectionsByIds(data, reversedIDs),
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+    directionalData.forEach(([declination, inclination], index) => {
+      expect(+declination.toFixed(1)).toBe(expected[index].Dgeo);
+      expect(+inclination.toFixed(1)).toBe(expected[index].Igeo);
+    });
+  });
+
+  it('stratigraphic reference: plotted strat coords equal the strat transform', () => {
+    const { directionalData } = dataToStereoDIR(
+      data,
+      graphSize,
+      'stratigraphic',
+      noneHidden,
+      [],
+      true,
+      statistics,
+      false,
+    );
+    const expected = centerDirectionsByMean(
+      data,
+      geographicMean,
+      stratigraphicMean,
+    ).interpretations;
+    directionalData.forEach(([declination, inclination], index) => {
+      expect(+declination.toFixed(1)).toBe(expected[index].Dstrat);
+      expect(+inclination.toFixed(1)).toBe(expected[index].Istrat);
+    });
+  });
+
+  // The four assertions above lock plot↔export AGREEMENT (both route through the
+  // shared centerDirectionOnMean). This one is an INDEPENDENT geometric oracle so
+  // a regression in the centering math itself is also caught here: after
+  // centering, each plotted dot must sit as far from the stereonet centre (0, 90)
+  // as the raw direction was from the mean.
+  it('centered plot positions match an independent oracle (distance-to-centre == distance-to-mean)', () => {
+    const { directionalData } = dataToStereoDIR(
+      data,
+      graphSize,
+      'geographic',
+      noneHidden,
+      [],
+      true,
+      statistics,
+      false,
+    );
+    const centre = new Direction(0, 90, 1);
+    directionalData.forEach(([declination, inclination], index) => {
+      const raw = data.interpretations[index];
+      const distanceFromMean = geographicMean.angle(new Direction(raw.Dgeo, raw.Igeo, 1));
+      const distanceFromCentre = centre.angle(new Direction(declination, inclination, 1));
+      expect(distanceFromCentre).toBeCloseTo(distanceFromMean, 3);
+    });
+  });
+});

--- a/src/utils/graphs/formatters/stereo/dataToStereoDIR.ts
+++ b/src/utils/graphs/formatters/stereo/dataToStereoDIR.ts
@@ -6,7 +6,8 @@ import { dirToCartesian2D } from '../../dirToCartesian';
 import { graphSelectedDotColor } from '../../../ThemeConstants';
 import createStereoPlaneData from './createPlaneData/createStereoPlaneData';
 import Direction from '../../classes/Direction';
-import { strangeRotation } from '../../../statistics/matrix';
+import centerDirectionOnMean from '../../centerDirectionOnMean';
+import reverseDirectionsByIds from '../../../files/transforms/reverseDirectionsByIds';
 import calculateCutoff from '../../../statistics/calculation/calculateCutoff';
 
 const dataToStereoDIR = (
@@ -19,30 +20,17 @@ const dataToStereoDIR = (
   statistics?: RawStatisticsDIR,
   cutoff?: boolean,
 ) => {
-  let directions = data.interpretations.filter(
+  // Reverse polarity first (by id), then drop hidden directions. Reversal
+  // preserves order and count, so the index-based hidden filter is unaffected.
+  // Uses the shared reverseDirectionsByIds so the plotted dots flip exactly the
+  // same way (and with the same 0.1° rounding) as the table and the export.
+  const reversedInterpretations = reverseDirectionsByIds(
+    data,
+    reversedDirectionsIDs,
+  ).interpretations;
+  const directions = reversedInterpretations.filter(
     (direction, index) => !hiddenDirectionsIDs.includes(index + 1),
   );
-
-  directions = directions.map((direction, index) => {
-    const { id, Dgeo, Igeo, Dstrat, Istrat } = direction;
-    let geoDirection = new Direction(Dgeo, Igeo, 1);
-    let stratDirection = new Direction(Dstrat, Istrat, 1);
-    if (reversedDirectionsIDs.includes(id)) {
-      geoDirection = geoDirection.reversePolarity();
-      stratDirection = stratDirection.reversePolarity();
-    }
-    const DgeoFinal = +geoDirection.declination.toFixed(1);
-    const IgeoFinal = +geoDirection.inclination.toFixed(1);
-    const DstratFinal = +stratDirection.declination.toFixed(1);
-    const IstratFinal = +stratDirection.inclination.toFixed(1);
-    return {
-      ...direction,
-      Dgeo: DgeoFinal,
-      Igeo: IgeoFinal,
-      Dstrat: DstratFinal,
-      Istrat: IstratFinal,
-    };
-  });
 
   // annotations for dots ('id' field added right in the Data.tsx as dot index)
   const labels = directions.map((direction) => direction.label);
@@ -120,12 +108,11 @@ const dataToStereoDIR = (
       reference === 'stratigraphic' ? [Dstrat, Istrat] : [Dgeo, Igeo];
     let finalCoords: [number, number] = inReferenceCoords;
     if (centeredByMean && meanDirection) {
-      const directionVector = new Direction(finalCoords[0], finalCoords[1], 1);
-      const firstRotationDirection = new Direction(meanDirection.dirData[0], 0, 1);
-      const secondRotationDirection = new Direction(0, meanDirection.dirData[1] - 90, 1);
-      const firstRotation = strangeRotation(directionVector, firstRotationDirection);
-      const secondRotation = strangeRotation(firstRotation, secondRotationDirection);
-      finalCoords = secondRotation.toArray();
+      finalCoords = centerDirectionOnMean(
+        finalCoords[0],
+        finalCoords[1],
+        new Direction(meanDirection.dirData[0], meanDirection.dirData[1], 1),
+      );
     }
     return finalCoords;
   });

--- a/test-data/v2.6.4/verify-fixes.md
+++ b/test-data/v2.6.4/verify-fixes.md
@@ -1,66 +1,68 @@
-# Verify: DIR "Export centered" feature (apr-rv-last)
+# Verify: DIR center-by-mean export + CUT45 (apr-rv-last)
 
-Feature: the DIR Directional-Statistics module can now export the directions
-**rotated so the Fisher mean sits at the centre of the stereonet**, to PMM, CSV
-and XLSX — not just as graphics. Cut directions are tagged `CUT95` when the 45°
-cutoff is on. Test on the DIR page with `test-data/sample.dir`.
+The DIR module now exports the **main directions table** (the big bottom table)
+rotated so the Fisher mean sits at the centre of the stereonet, plus a new
+**"Export with hidden"** variant that keeps the cutoff-rejected directions and
+tags them `CUT45`. Test on **/app/dir** with `test-data/sample.dir`.
 
 ## Setup
-1. Open the app, go to **/app/dir**.
-2. Upload `test-data/sample.dir` (8 directions: alternating normal ~D340/I+37 and
-   reversed ~D145/I−42).
-3. Compute a mean: select a statistics mode (**Fisher**) so a mean direction and
-   its confidence circle appear on the stereonet. This is required — the centered
-   export only appears once a mean exists.
+1. Open **/app/dir**, upload `test-data/sample.dir` (8 directions: alternating
+   normal ~D340/I+37 and reversed ~D145/I−42).
+2. Select statistics mode **Fisher** so a mean direction appears on the stereonet.
+   (Centering needs a mean.)
+3. All checks below are about the **bottom big table** (`DataTableDIR`) and its
+   **Export** menu — not the small statistics table on top.
 
-## 1. New menu items appear only with a mean
-- Open the table toolbar **Export** menu. With a mean computed you should see the
-  regular items (**Export as PMM / CSV / XLSX**) **plus** three new ones:
-  **Export centered as PMM**, **Export centered as CSV**, **Export centered as XLSX**.
-- Before any mean is computed (fresh reload, no statistics mode), the "Export
-  centered as …" items must **not** be present.
+## 1. "Center by mean" now updates the table
+- Toggle **Center by mean** on the stereonet **on**.
+- The bottom table's **Dgeo/Igeo and Dstrat/Istrat columns must change** (rotated
+  values) — previously they did not react. Toggling it **off** restores the
+  original values. Points on the graph move as before.
 
-## 2. Centered export recomputes D/I, mean → centre
-- Click **Export centered as CSV**. Open the downloaded file.
-- Compared with the file from plain **Export as CSV**: every row must have the
-  **same** id/Code/StepRange/N/K/MAD/Comment, but **different Dgeo/Igeo and
-  Dstrat/Istrat** (rotated values).
-- Sanity check the rotation: the centred directions should cluster near the centre
-  of a stereonet, i.e. the **inclinations move toward ±90** relative to the mean.
-  A direction that equals the mean comes out at inclination ≈ **90.0**.
-- Values are rounded to **one decimal place** (e.g. `12.3`, never `12.345`).
+## 2. Regular export reflects the toggle
+- With **Center by mean OFF**: open the bottom table's **Export** menu →
+  **Export as CSV**. The file holds the **original** Dgeo/Igeo.
+- With **Center by mean ON**: **Export as CSV** again → the file holds the
+  **rotated** Dgeo/Igeo (same values the table now shows). Values rounded to 0.1°.
+- The regular export still **excludes** directions hidden on the graph.
 
-## 3. CUT95 only when the 45° cutoff is enabled
-- On the stereonet, toggle the **cutoff** control **on** (45°) and turn on
-  **show outer dots** so the rejected directions remain visible.
-- **Export centered as CSV** again. In the `Comment` column, the directions that
-  fall **outside** the 45° circle (far from the mean) must contain **`CUT95`**.
-  Directions inside the circle must **not** contain it. If a direction already had
-  a comment, it becomes `…; CUT95` (existing text preserved).
-- Turn the cutoff **off**, export again → **no** `CUT95` anywhere.
-- Export centered **twice** with cutoff on → still a single `CUT95` per row (no
-  `CUT95; CUT95` duplication).
+## 3. New "Export with hidden as PMM/CSV/XLSX"
+- The Export menu shows three new items: **Export with hidden as PMM / CSV / XLSX**
+  below the regular ones.
+- These include **every** direction — even ones hidden on the graph — whereas the
+  regular export drops hidden ones. Hide a direction (eye icon) and compare:
+  the regular CSV omits it; the "with hidden" CSV keeps it.
 
-## 4. "Exactly what is visible on the graph"
-- **Hide** one direction (e.g. via the table/graph hide control). Export centered
-  → the hidden direction is **absent** from the exported file.
-- **Reverse** one direction (reverse-polarity control). Export centered → that
-  direction's exported D/I reflect the **flipped** polarity (declination +180,
-  inclination negated) before centering.
+## 4. Cutoff → CUT45 in "Export with hidden"
+- Enable the **45° cutoff** on the stereonet (the outliers get hidden on the
+  graph and drop out of the table).
+- **Export with hidden as CSV**. In the `Comment` column, the directions beyond
+  45° from the mean must contain **`CUT45`**:
+  - empty comment → `CUT45`
+  - existing comment `foo` → `foo; CUT45`
+- Directions inside 45° keep their original comment (no `CUT45`).
+- Export **with hidden** twice → still a single `CUT45` per row (no
+  `CUT45; CUT45`).
+- Disable the cutoff → **Export with hidden** has **no** `CUT45` anywhere (but
+  still includes all directions).
+- The **regular** export never adds `CUT45` (and drops the hidden/cut rows).
 
-## 5. Regression — plain exports unchanged
-- **Export as PMM / CSV / XLSX** (the non-centered items) still download and show
-  the **original** Dgeo/Igeo (no rotation, no CUT95).
-- The regular cutoff behaviour on the graph (hide/show outer dots, border circle)
-  still works as before after the cutoff state moved into Redux.
+## 5. Reversed directions
+- Reverse one direction (swap-polarity icon). Both the table and every export
+  show the **flipped** D/I (declination +180, inclination negated), then centered
+  if the toggle is on.
 
-## 6. No console errors / stray glyph
-- Open DevTools console. Perform the steps above. There should be **no** errors or
-  new React warnings.
-- The Export menu must **not** show a stray lone "я" character (a pre-existing
-  typo that was removed in this change).
+## 6. No mean → no centering, no crash
+- Before computing a Fisher mean (fresh reload), the **Center by mean** toggle has
+  nothing to centre on: the table shows raw values and exports are unrotated. No
+  console errors.
+
+## 7. Console / regression
+- DevTools console: no errors or new React warnings through all steps.
+- The small **statistics table on top** is unchanged (no "Export with hidden"
+  there — that change was reverted).
+- The Export menu shows no stray "я" glyph (pre-existing typo removed).
 
 ## Companion issue (no app change expected)
-- `may-rv-1` (SQUID/ARM): no UI change. Optionally confirm that uploading a
-  `.squid` file with an `ARM` block still imports only the AF steps before `ARM`
-  (already handled by parserSQUID). `.claude/issues/may-rv-1/70.squid` is a sample.
+- `may-rv-1` (SQUID/ARM): no UI change. Uploading a `.squid` with an `ARM` block
+  still imports only the AF steps before `ARM` (handled by parserSQUID).

--- a/test-data/v2.6.4/verify-fixes.md
+++ b/test-data/v2.6.4/verify-fixes.md
@@ -1,0 +1,66 @@
+# Verify: DIR "Export centered" feature (apr-rv-last)
+
+Feature: the DIR Directional-Statistics module can now export the directions
+**rotated so the Fisher mean sits at the centre of the stereonet**, to PMM, CSV
+and XLSX — not just as graphics. Cut directions are tagged `CUT95` when the 45°
+cutoff is on. Test on the DIR page with `test-data/sample.dir`.
+
+## Setup
+1. Open the app, go to **/app/dir**.
+2. Upload `test-data/sample.dir` (8 directions: alternating normal ~D340/I+37 and
+   reversed ~D145/I−42).
+3. Compute a mean: select a statistics mode (**Fisher**) so a mean direction and
+   its confidence circle appear on the stereonet. This is required — the centered
+   export only appears once a mean exists.
+
+## 1. New menu items appear only with a mean
+- Open the table toolbar **Export** menu. With a mean computed you should see the
+  regular items (**Export as PMM / CSV / XLSX**) **plus** three new ones:
+  **Export centered as PMM**, **Export centered as CSV**, **Export centered as XLSX**.
+- Before any mean is computed (fresh reload, no statistics mode), the "Export
+  centered as …" items must **not** be present.
+
+## 2. Centered export recomputes D/I, mean → centre
+- Click **Export centered as CSV**. Open the downloaded file.
+- Compared with the file from plain **Export as CSV**: every row must have the
+  **same** id/Code/StepRange/N/K/MAD/Comment, but **different Dgeo/Igeo and
+  Dstrat/Istrat** (rotated values).
+- Sanity check the rotation: the centred directions should cluster near the centre
+  of a stereonet, i.e. the **inclinations move toward ±90** relative to the mean.
+  A direction that equals the mean comes out at inclination ≈ **90.0**.
+- Values are rounded to **one decimal place** (e.g. `12.3`, never `12.345`).
+
+## 3. CUT95 only when the 45° cutoff is enabled
+- On the stereonet, toggle the **cutoff** control **on** (45°) and turn on
+  **show outer dots** so the rejected directions remain visible.
+- **Export centered as CSV** again. In the `Comment` column, the directions that
+  fall **outside** the 45° circle (far from the mean) must contain **`CUT95`**.
+  Directions inside the circle must **not** contain it. If a direction already had
+  a comment, it becomes `…; CUT95` (existing text preserved).
+- Turn the cutoff **off**, export again → **no** `CUT95` anywhere.
+- Export centered **twice** with cutoff on → still a single `CUT95` per row (no
+  `CUT95; CUT95` duplication).
+
+## 4. "Exactly what is visible on the graph"
+- **Hide** one direction (e.g. via the table/graph hide control). Export centered
+  → the hidden direction is **absent** from the exported file.
+- **Reverse** one direction (reverse-polarity control). Export centered → that
+  direction's exported D/I reflect the **flipped** polarity (declination +180,
+  inclination negated) before centering.
+
+## 5. Regression — plain exports unchanged
+- **Export as PMM / CSV / XLSX** (the non-centered items) still download and show
+  the **original** Dgeo/Igeo (no rotation, no CUT95).
+- The regular cutoff behaviour on the graph (hide/show outer dots, border circle)
+  still works as before after the cutoff state moved into Redux.
+
+## 6. No console errors / stray glyph
+- Open DevTools console. Perform the steps above. There should be **no** errors or
+  new React warnings.
+- The Export menu must **not** show a stray lone "я" character (a pre-existing
+  typo that was removed in this change).
+
+## Companion issue (no app change expected)
+- `may-rv-1` (SQUID/ARM): no UI change. Optionally confirm that uploading a
+  `.squid` file with an `ARM` block still imports only the AF steps before `ARM`
+  (already handled by parserSQUID). `.claude/issues/may-rv-1/70.squid` is a sample.

--- a/test-data/v2.6.4/verify-fixes.md
+++ b/test-data/v2.6.4/verify-fixes.md
@@ -35,7 +35,8 @@ tags them `CUT45`. Test on **/app/dir** with `test-data/sample.dir`.
 
 ## 4. Cutoff → CUT45 in "Export with hidden"
 - Enable the **45° cutoff** on the stereonet (the outliers get hidden on the
-  graph and drop out of the table).
+  graph; in the bottom table they stay listed but their index column shows `-`,
+  and they are dropped from the regular export).
 - **Export with hidden as CSV**. In the `Comment` column, the directions beyond
   45° from the mean must contain **`CUT45`**:
   - empty comment → `CUT45`
@@ -51,6 +52,12 @@ tags them `CUT45`. Test on **/app/dir** with `test-data/sample.dir`.
 - Reverse one direction (swap-polarity icon). Both the table and every export
   show the **flipped** D/I (declination +180, inclination negated), then centered
   if the toggle is on.
+- **Reversal + cutoff (regression).** Reverse the whole reverse-polarity cluster
+  (e.g. test02/04/06/08), Fisher-mean all 8 → one tight cluster on the mean. Enable
+  the **45° cutoff**: the drawn circle must match what it cuts — directions **inside**
+  the circle stay, none of the aligned cluster is hidden (the table keeps indices
+  1–8, no `-`). Directions visibly **outside** the circle (e.g. a reverse-polarity
+  one left un-reversed) are still cut. Switching Geo↔Strat re-evaluates the cutoff.
 
 ## 6. No mean → no centering, no crash
 - Before computing a Fisher mean (fresh reload), the **Center by mean** toggle has


### PR DESCRIPTION
## Summary

Implements the **apr-rv-last** feature request (R.V. Veselovskiy): in the DIR
"Directional Statistics" module, export the directions **rotated so the Fisher
mean sits at the centre of the stereonet** as data (PMM / CSV / XLSX) — not just
as graphics — with `CUT95` tagging for directions rejected by the 45° cutoff.

The source file is reproduced with **only D/I recomputed**; all other fields are
preserved. Centering matches the existing on-screen "Center by mean" view (same
`strangeRotation`).

## What changed

- **New pure transforms** (`src/utils/files/transforms/`):
  - `centerDirectionsByMean` — rotates `Dgeo/Igeo` about the geographic mean and
    `Dstrat/Istrat` about the stratigraphic mean (both sets, each its own mean),
    reusing the exact two-step rotation from `dataToStereoDIR`.
  - `markCutoffComments` — appends `CUT95` to the comment of directions beyond the
    cutoff angle from the mean (same predicate as the 45° cutoff on the stereonet).
  - Reference-output unit tests for both (10 tests): mean→centre invariant, angle
    preservation, field preservation, CUT95 marking, append-to-existing, idempotency.
- **Redux**: lifted `cutoffEnabled` / `cutoffAngle` from `DIRPage/Graphs` local
  state into the `dirPage` slice so the export menu can read the cutoff state.
- **UI**: `DIRStatisticsDataTableToolbar` builds the centered payload from exactly
  the directions visible on the graph (hidden dropped, reversed flipped), marks
  CUT95 when the cutoff is on, then centers. New **"Export centered as PMM/CSV/XLSX"**
  menu items appear only when a mean exists. `DIRExportMenuItem` gained an optional
  `label` prop.

## Design decisions (confirmed with @I194)
- Rotate **both** geo and strat coordinate sets.
- `CUT95` **only** when the 45° cutoff is enabled in the view.
- **New** menu items ("Export centered as …"); existing exports untouched.
- **No `.dir`** export added on the DIR page (kept as before).
- Export "exactly what is visible on the graph".

## Incidental cleanup
- Removed dead imports and a stray `я` text node in `ExportDIRFromDIR` that
  rendered as junk in the export menu (lint warnings 465 → 460).

## Out of scope (no change)
- Companion issue **may-rv-1** (SQUID `ARM`-block truncation + Oersted→mT) is
  already handled in `parserSQUID.ts`; RV confirmed the current behaviour. No code
  change needed.

## Verification
- `npm run verify` ✅ (0 errors) · `npm run build` ✅ · full test suite ✅ (119/119)
- Manual QA prompt for the Evaluator: `test-data/v2.6.4/verify-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
